### PR TITLE
47-add-self-hosted-runner

### DIFF
--- a/.github/workflows/scheduled_tests.yaml
+++ b/.github/workflows/scheduled_tests.yaml
@@ -1,0 +1,68 @@
+name: Scheduled
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+  # runs every day at 09:00 UTC
+  schedule:
+    - cron: '0 9 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip nox
+      - name: Unit tests with nox
+        run: |
+          nox -s unit
+  
+    #M-series Mac Mini
+  build-apple-mseries:
+    needs: style
+    runs-on: [self-hosted, macOS, ARM64]
+    env:
+      GITHUB_PATH: ${PYENV_ROOT/bin:$PATH}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install python & create virtualenv
+        shell: bash
+        run: |
+          eval "$(pyenv init -)"
+          pyenv install ${{ matrix.python-version }} -s
+          pyenv virtualenv ${{ matrix.python-version }} pybop-${{ matrix.python-version }}
+
+      - name: Install dependencies & run unit tests for Windows and MacOS
+        shell: bash
+        run: |
+          eval "$(pyenv init -)"
+          pyenv activate pybop-${{ matrix.python-version }}
+          python -m pip install --upgrade pip nox
+          python -m nox -s unit
+
+      - name: Uninstall pyenv-virtualenv & python
+        if: always()
+        shell: bash
+        run: |
+          eval "$(pyenv init -)"
+          pyenv activate pybop-${{ matrix.python-version }}
+          pyenv uninstall -f $( python --version )

--- a/.github/workflows/scheduled_tests.yaml
+++ b/.github/workflows/scheduled_tests.yaml
@@ -55,7 +55,7 @@ jobs:
         run: |
           eval "$(pyenv init -)"
           pyenv activate pybop-${{ matrix.python-version }}
-          python -m pip install --upgrade pip nox wheel
+          python -m pip install --upgrade pip wheel setuptools nox
           python -m nox -s unit
 
       - name: Uninstall pyenv-virtualenv & python

--- a/.github/workflows/scheduled_tests.yaml
+++ b/.github/workflows/scheduled_tests.yaml
@@ -50,12 +50,12 @@ jobs:
           pyenv install ${{ matrix.python-version }} -s
           pyenv virtualenv ${{ matrix.python-version }} pybop-${{ matrix.python-version }}
 
-      - name: Install dependencies & run unit tests for Windows and MacOS
+      - name: Install dependencies & run unit tests
         shell: bash
         run: |
           eval "$(pyenv init -)"
           pyenv activate pybop-${{ matrix.python-version }}
-          python -m pip install --upgrade pip nox
+          python -m pip install --upgrade pip nox wheel
           python -m nox -s unit
 
       - name: Uninstall pyenv-virtualenv & python

--- a/.github/workflows/scheduled_tests.yaml
+++ b/.github/workflows/scheduled_tests.yaml
@@ -3,8 +3,8 @@ name: Scheduled
 on:
   workflow_dispatch:
   pull_request:
-    # branches:
-    #   - main
+    branches:
+      - main
 
   # runs every day at 09:00 UTC
   schedule:
@@ -29,11 +29,10 @@ jobs:
           python -m pip install --upgrade pip nox
       - name: Unit tests with nox
         run: |
-          nox -s unit
+          python -m nox -s unit
   
     #M-series Mac Mini
   build-apple-mseries:
-    needs: style
     runs-on: [self-hosted, macOS, ARM64]
     env:
       GITHUB_PATH: ${PYENV_ROOT/bin:$PATH}

--- a/.github/workflows/scheduled_tests.yaml
+++ b/.github/workflows/scheduled_tests.yaml
@@ -3,8 +3,8 @@ name: Scheduled
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
+    # branches:
+    #   - main
 
   # runs every day at 09:00 UTC
   schedule:

--- a/.github/workflows/scheduled_tests.yaml
+++ b/.github/workflows/scheduled_tests.yaml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -1,4 +1,4 @@
-name: PyBOP
+name: test_on_push
 
 on:
   push:
@@ -29,9 +29,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade pip nox
-          pip install -e .
+          python -m pip install --upgrade pip nox
       - name: Unit tests with nox
         run: |
           nox -s unit
@@ -56,10 +54,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade pip nox
-          pip install -e .
-
+          python -m pip install --upgrade pip nox
       - name: Run coverage tests for Ubuntu with Python 3.11 and generate report
         run: nox -s coverage
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
   <img src="https://raw.githubusercontent.com/pybop-team/PyBOP/develop/assets/Temp_Logo.png" alt="logo" width="400" height="auto" />
   <h1>Python Battery Optimisation and Parameterisation</h1>
 
-
 <p>
-  <a href="https://github.com/pybop-team/PyBOP/actions/workflows/test_on_push.yaml">
-    <img src="https://img.shields.io/github/actions/workflow/status/pybop-team/PyBOP/test_on_push.yaml?label=Build%20Status" alt="build" />
+  <a href="https://github.com/pybop-team/PyBOP/actions/workflows/scheduled_tests.yaml">
+    <img src="https://github.com/pybop-team/PyBOP/actions/workflows/scheduled_tests.yaml/badge.svg" alt="Scheduled" />
   </a>
   <a href="https://github.com/pybop-team/PyBOP/graphs/contributors">
     <img src="https://img.shields.io/github/contributors/pybop-team/PyBOP" alt="contributors" />


### PR DESCRIPTION
This PR adds a daily triggered unit test to be completed on the self-hosted M2 mini as well as the GitHub-hosted runners.

Note, the workflow names have been updated to align with their tasks. The dependency installations have also been refactored as there was redundant code. Closes #47 