### PR TITLE
Ruff pre-commit updates (#83)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,17 +4,12 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.0.292"
+    rev: "v0.1.3"
     hooks:
       - id: ruff
-        args: ["--fix", "--ignore=E501,E402,E741", "--exclude=__init__.py"]
-
-  - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.7.0
-    hooks:
-      - id: nbqa-ruff
-        additional_dependencies: [ruff==0.0.284]
-        args: ["--fix","--ignore=E501,E402"]
+        args: [--fix, --show-fixes]
+        types_or: [python, pyi, jupyter]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,21 +3,16 @@ import nox
 # nox options
 nox.options.reuse_existing_virtualenvs = True
 
-# @nox.session
-# def lint(session):
-#     session.install('flake8')
-#     session.run('flake8', 'example.py')
-
 
 @nox.session
 def unit(session):
     session.run_always("pip", "install", "-e", ".")
     session.install("pytest")
-    session.run("pytest", "--unit")
+    session.run("pytest", "--unit", "-v")
 
 
 @nox.session
 def coverage(session):
     session.run_always("pip", "install", "-e", ".")
     session.install("pytest-cov")
-    session.run("pytest", "--unit", "--cov", "--cov-report=xml")
+    session.run("pytest", "--unit", "-v", "--cov", "--cov-report=xml")

--- a/pybop/parameters/base_parameter_set.py
+++ b/pybop/parameters/base_parameter_set.py
@@ -8,9 +8,6 @@ class ParameterSet:
 
     def __new__(cls, method, name):
         if method.casefold() == "pybamm":
-            try:
-                return pybamm.ParameterValues(name).copy()
-            except:
-                raise ValueError("Parameter set not found")
+            return pybamm.ParameterValues(name).copy()
         else:
             raise ValueError("Only PyBaMM parameter sets are currently implemented")

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,8 @@
+extend-include = ["*.ipynb"]
+extend-exclude = ["__init__.py"]
+
+[lint]
+ignore = ["E501","E741"]
+
+[lint.per-file-ignores]
+"**.ipynb" = ["E402", "E703"]


### PR DESCRIPTION
- Closes #83. 
- Fixes linting errors found in the repo during the process.
- Add verbose output to pytest --unit tests