### PR TITLE
Add jupyter notebook test methods

### DIFF
--- a/.github/workflows/scheduled_tests.yaml
+++ b/.github/workflows/scheduled_tests.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: Unit tests with nox
         run: |
           python -m nox -s unit
+          python -m nox -s notebooks
 
     #M-series Mac Mini
   build-apple-mseries:
@@ -57,6 +58,7 @@ jobs:
           pyenv activate pybop-${{ matrix.python-version }}
           python -m pip install --upgrade pip wheel setuptools nox
           python -m nox -s unit
+          python -m nox -s notebooks
 
       - name: Uninstall pyenv-virtualenv & python
         if: always()

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,3 +16,11 @@ def coverage(session):
     session.run_always("pip", "install", "-e", ".")
     session.install("pytest-cov")
     session.run("pytest", "--unit", "-v", "--cov", "--cov-report=xml")
+
+
+@nox.session
+def notebooks(session):
+    """Run the examples tests for Jupyter notebooks."""
+    session.run_always("pip", "install", "-e", ".")
+    session.install("pytest", "nbmake")
+    session.run("pytest", "--nbmake", "examples/", external=True)


### PR DESCRIPTION
Closes #87. Adds a nox session to test notebooks:  `nox -s notebooks`

Also adds a trigger to the scheduled tests.