### PR TITLE
Adds Pints' optimisers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [Unreleased](https://github.com/pybop-team/PyBOP)
 
+    - Adds PSO, SNES, XNES, ADAM, and IPropMin optimisers to PintsOptimisers() class
+
 # [v23.11](https://github.com/pybop-team/PyBOP/releases/tag/v23.11)
     - Initial release
     - Adds Pints, NLOpt, and SciPy optimisers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # [Unreleased](https://github.com/pybop-team/PyBOP)
 
-    - Adds PSO, SNES, XNES, ADAM, and IPropMin optimisers to PintsOptimisers() class
+- [#116](https://github.com/pybop-team/PyBOP/issues/116) - Adds PSO, SNES, XNES, ADAM, and IPropMin optimisers to PintsOptimisers() class
 
 # [v23.11](https://github.com/pybop-team/PyBOP/releases/tag/v23.11)
-    - Initial release
-    - Adds Pints, NLOpt, and SciPy optimisers
-    - Adds SumofSquareError and RootMeanSquareError cost functions
-    - Adds Parameter and dataset classes
+- Initial release
+- Adds Pints, NLOpt, and SciPy optimisers
+- Adds SumofSquareError and RootMeanSquareError cost functions
+- Adds Parameter and dataset classes

--- a/conftest.py
+++ b/conftest.py
@@ -12,13 +12,21 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "unit: mark test as a unit test")
+    config.addinivalue_line("markers", "examples: mark test as an example")
 
 
 def pytest_collection_modifyitems(config, items):
+    def skip_marker(marker_name, reason):
+        skip = pytest.mark.skip(reason=reason)
+        for item in items:
+            if marker_name in item.keywords:
+                item.add_marker(skip)
+
     if config.getoption("--unit"):
-        # --unit given in cli: do not skip unit tests
+        skip_marker("examples", "need --examples option to run")
         return
-    skip_unit = pytest.mark.skip(reason="need --unit option to run")
-    for item in items:
-        if "unit" in item.keywords:
-            item.add_marker(skip_unit)
+
+    if config.getoption("--examples"):
+        return
+
+    skip_marker("unit", "need --unit option to run")

--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,9 @@ def pytest_addoption(parser):
     parser.addoption(
         "--unit", action="store_true", default=False, help="run unit tests"
     )
+    parser.addoption(
+        "--examples", action="store_true", default=False, help="run examples tests"
+    )
 
 
 def pytest_configure(config):
@@ -27,6 +30,7 @@ def pytest_collection_modifyitems(config, items):
         return
 
     if config.getoption("--examples"):
+        skip_marker("unit", "need --unit option to run")
         return
 
     skip_marker("unit", "need --unit option to run")

--- a/examples/scripts/spm_CMAES.py
+++ b/examples/scripts/spm_CMAES.py
@@ -1,0 +1,55 @@
+import pybop
+import numpy as np
+import matplotlib.pyplot as plt
+
+parameter_set = pybop.ParameterSet("pybamm", "Chen2020")
+model = pybop.lithium_ion.SPM(parameter_set=parameter_set)
+
+# Fitting parameters
+parameters = [
+    pybop.Parameter(
+        "Negative electrode active material volume fraction",
+        prior=pybop.Gaussian(0.7, 0.05),
+        bounds=[0.6, 0.9],
+    ),
+    pybop.Parameter(
+        "Positive electrode active material volume fraction",
+        prior=pybop.Gaussian(0.58, 0.05),
+        bounds=[0.5, 0.8],
+    ),
+]
+
+sigma = 0.001
+t_eval = np.arange(0, 900, 2)
+values = model.predict(t_eval=t_eval)
+CorruptValues = values["Terminal voltage [V]"].data + np.random.normal(
+    0, sigma, len(t_eval)
+)
+
+dataset = [
+    pybop.Dataset("Time [s]", t_eval),
+    pybop.Dataset("Current function [A]", values["Current [A]"].data),
+    pybop.Dataset("Terminal voltage [V]", CorruptValues),
+]
+
+# Generate problem, cost function, and optimisation class
+problem = pybop.Problem(model, parameters, dataset)
+cost = pybop.SumSquaredError(problem)
+optim = pybop.Optimisation(cost, optimiser=pybop.CMAES)
+optim.set_max_iterations(100)
+
+x, final_cost = optim.run()
+print("Estimated parameters:", x)
+
+# Show the generated data
+simulated_values = problem.evaluate(x)
+
+plt.figure(dpi=100)
+plt.xlabel("Time", fontsize=12)
+plt.ylabel("Values", fontsize=12)
+plt.plot(t_eval, CorruptValues, label="Measured")
+plt.fill_between(t_eval, simulated_values - sigma, simulated_values + sigma, alpha=0.2)
+plt.plot(t_eval, simulated_values, label="Simulated")
+plt.legend(bbox_to_anchor=(0.6, 1), loc="upper left", fontsize=12)
+plt.tick_params(axis="both", labelsize=12)
+plt.show()

--- a/examples/scripts/spm_IRPropMin.py
+++ b/examples/scripts/spm_IRPropMin.py
@@ -1,0 +1,55 @@
+import pybop
+import numpy as np
+import matplotlib.pyplot as plt
+
+parameter_set = pybop.ParameterSet("pybamm", "Chen2020")
+model = pybop.lithium_ion.SPM(parameter_set=parameter_set)
+
+# Fitting parameters
+parameters = [
+    pybop.Parameter(
+        "Negative electrode active material volume fraction",
+        prior=pybop.Gaussian(0.7, 0.05),
+        bounds=[0.6, 0.9],
+    ),
+    pybop.Parameter(
+        "Positive electrode active material volume fraction",
+        prior=pybop.Gaussian(0.58, 0.05),
+        bounds=[0.5, 0.8],
+    ),
+]
+
+sigma = 0.001
+t_eval = np.arange(0, 900, 2)
+values = model.predict(t_eval=t_eval)
+CorruptValues = values["Terminal voltage [V]"].data + np.random.normal(
+    0, sigma, len(t_eval)
+)
+
+dataset = [
+    pybop.Dataset("Time [s]", t_eval),
+    pybop.Dataset("Current function [A]", values["Current [A]"].data),
+    pybop.Dataset("Terminal voltage [V]", CorruptValues),
+]
+
+# Generate problem, cost function, and optimisation class
+problem = pybop.Problem(model, parameters, dataset)
+cost = pybop.SumSquaredError(problem)
+optim = pybop.Optimisation(cost, optimiser=pybop.IRPropMin)
+optim.set_max_iterations(100)
+
+x, final_cost = optim.run()
+print("Estimated parameters:", x)
+
+# Show the generated data
+simulated_values = problem.evaluate(x)
+
+plt.figure(dpi=100)
+plt.xlabel("Time", fontsize=12)
+plt.ylabel("Values", fontsize=12)
+plt.plot(t_eval, CorruptValues, label="Measured")
+plt.fill_between(t_eval, simulated_values - sigma, simulated_values + sigma, alpha=0.2)
+plt.plot(t_eval, simulated_values, label="Simulated")
+plt.legend(bbox_to_anchor=(0.6, 1), loc="upper left", fontsize=12)
+plt.tick_params(axis="both", labelsize=12)
+plt.show()

--- a/examples/scripts/spm_SNES.py
+++ b/examples/scripts/spm_SNES.py
@@ -1,0 +1,55 @@
+import pybop
+import numpy as np
+import matplotlib.pyplot as plt
+
+parameter_set = pybop.ParameterSet("pybamm", "Chen2020")
+model = pybop.lithium_ion.SPM(parameter_set=parameter_set)
+
+# Fitting parameters
+parameters = [
+    pybop.Parameter(
+        "Negative electrode active material volume fraction",
+        prior=pybop.Gaussian(0.7, 0.05),
+        bounds=[0.6, 0.9],
+    ),
+    pybop.Parameter(
+        "Positive electrode active material volume fraction",
+        prior=pybop.Gaussian(0.58, 0.05),
+        bounds=[0.5, 0.8],
+    ),
+]
+
+sigma = 0.001
+t_eval = np.arange(0, 900, 2)
+values = model.predict(t_eval=t_eval)
+CorruptValues = values["Terminal voltage [V]"].data + np.random.normal(
+    0, sigma, len(t_eval)
+)
+
+dataset = [
+    pybop.Dataset("Time [s]", t_eval),
+    pybop.Dataset("Current function [A]", values["Current [A]"].data),
+    pybop.Dataset("Terminal voltage [V]", CorruptValues),
+]
+
+# Generate problem, cost function, and optimisation class
+problem = pybop.Problem(model, parameters, dataset)
+cost = pybop.SumSquaredError(problem)
+optim = pybop.Optimisation(cost, optimiser=pybop.SNES)
+optim.set_max_iterations(100)
+
+x, final_cost = optim.run()
+print("Estimated parameters:", x)
+
+# Show the generated data
+simulated_values = problem.evaluate(x)
+
+plt.figure(dpi=100)
+plt.xlabel("Time", fontsize=12)
+plt.ylabel("Values", fontsize=12)
+plt.plot(t_eval, CorruptValues, label="Measured")
+plt.fill_between(t_eval, simulated_values - sigma, simulated_values + sigma, alpha=0.2)
+plt.plot(t_eval, simulated_values, label="Simulated")
+plt.legend(bbox_to_anchor=(0.6, 1), loc="upper left", fontsize=12)
+plt.tick_params(axis="both", labelsize=12)
+plt.show()

--- a/examples/scripts/spm_XNES.py
+++ b/examples/scripts/spm_XNES.py
@@ -1,0 +1,55 @@
+import pybop
+import numpy as np
+import matplotlib.pyplot as plt
+
+parameter_set = pybop.ParameterSet("pybamm", "Chen2020")
+model = pybop.lithium_ion.SPM(parameter_set=parameter_set)
+
+# Fitting parameters
+parameters = [
+    pybop.Parameter(
+        "Negative electrode active material volume fraction",
+        prior=pybop.Gaussian(0.7, 0.05),
+        bounds=[0.6, 0.9],
+    ),
+    pybop.Parameter(
+        "Positive electrode active material volume fraction",
+        prior=pybop.Gaussian(0.58, 0.05),
+        bounds=[0.5, 0.8],
+    ),
+]
+
+sigma = 0.001
+t_eval = np.arange(0, 900, 2)
+values = model.predict(t_eval=t_eval)
+CorruptValues = values["Terminal voltage [V]"].data + np.random.normal(
+    0, sigma, len(t_eval)
+)
+
+dataset = [
+    pybop.Dataset("Time [s]", t_eval),
+    pybop.Dataset("Current function [A]", values["Current [A]"].data),
+    pybop.Dataset("Terminal voltage [V]", CorruptValues),
+]
+
+# Generate problem, cost function, and optimisation class
+problem = pybop.Problem(model, parameters, dataset)
+cost = pybop.SumSquaredError(problem)
+optim = pybop.Optimisation(cost, optimiser=pybop.XNES)
+optim.set_max_iterations(100)
+
+x, final_cost = optim.run()
+print("Estimated parameters:", x)
+
+# Show the generated data
+simulated_values = problem.evaluate(x)
+
+plt.figure(dpi=100)
+plt.xlabel("Time", fontsize=12)
+plt.ylabel("Values", fontsize=12)
+plt.plot(t_eval, CorruptValues, label="Measured")
+plt.fill_between(t_eval, simulated_values - sigma, simulated_values + sigma, alpha=0.2)
+plt.plot(t_eval, simulated_values, label="Simulated")
+plt.legend(bbox_to_anchor=(0.6, 1), loc="upper left", fontsize=12)
+plt.tick_params(axis="both", labelsize=12)
+plt.show()

--- a/examples/scripts/spm_adam.py
+++ b/examples/scripts/spm_adam.py
@@ -2,6 +2,7 @@ import pybop
 import numpy as np
 import matplotlib.pyplot as plt
 
+# Parameter set and model definition
 parameter_set = pybop.ParameterSet("pybamm", "Chen2020")
 model = pybop.lithium_ion.SPMe(parameter_set=parameter_set)
 
@@ -19,25 +20,28 @@ parameters = [
     ),
 ]
 
+# Generate data
 sigma = 0.001
 t_eval = np.arange(0, 900, 2)
 values = model.predict(t_eval=t_eval)
-CorruptValues = values["Terminal voltage [V]"].data + np.random.normal(
+corrupt_values = values["Terminal voltage [V]"].data + np.random.normal(
     0, sigma, len(t_eval)
 )
 
+# Dataset definition
 dataset = [
     pybop.Dataset("Time [s]", t_eval),
     pybop.Dataset("Current function [A]", values["Current [A]"].data),
-    pybop.Dataset("Terminal voltage [V]", CorruptValues),
+    pybop.Dataset("Terminal voltage [V]", corrupt_values),
 ]
 
 # Generate problem, cost function, and optimisation class
 problem = pybop.Problem(model, parameters, dataset)
 cost = pybop.SumSquaredError(problem)
-optim = pybop.Optimisation(cost, optimiser=pybop.CMAES)
+optim = pybop.Optimisation(cost, optimiser=pybop.Adam)
 optim.set_max_iterations(100)
 
+# Run optimisation
 x, final_cost = optim.run()
 print("Estimated parameters:", x)
 
@@ -47,7 +51,7 @@ simulated_values = problem.evaluate(x)
 plt.figure(dpi=100)
 plt.xlabel("Time", fontsize=12)
 plt.ylabel("Values", fontsize=12)
-plt.plot(t_eval, CorruptValues, label="Measured")
+plt.plot(t_eval, corrupt_values, label="Measured")
 plt.fill_between(t_eval, simulated_values - sigma, simulated_values + sigma, alpha=0.2)
 plt.plot(t_eval, simulated_values, label="Simulated")
 plt.legend(bbox_to_anchor=(0.6, 1), loc="upper left", fontsize=12)

--- a/examples/scripts/spm_pso.py
+++ b/examples/scripts/spm_pso.py
@@ -1,0 +1,55 @@
+import pybop
+import numpy as np
+import matplotlib.pyplot as plt
+
+parameter_set = pybop.ParameterSet("pybamm", "Chen2020")
+model = pybop.lithium_ion.SPM(parameter_set=parameter_set)
+
+# Fitting parameters
+parameters = [
+    pybop.Parameter(
+        "Negative electrode active material volume fraction",
+        prior=pybop.Gaussian(0.7, 0.05),
+        bounds=[0.6, 0.9],
+    ),
+    pybop.Parameter(
+        "Positive electrode active material volume fraction",
+        prior=pybop.Gaussian(0.58, 0.05),
+        bounds=[0.5, 0.8],
+    ),
+]
+
+sigma = 0.001
+t_eval = np.arange(0, 900, 2)
+values = model.predict(t_eval=t_eval)
+CorruptValues = values["Terminal voltage [V]"].data + np.random.normal(
+    0, sigma, len(t_eval)
+)
+
+dataset = [
+    pybop.Dataset("Time [s]", t_eval),
+    pybop.Dataset("Current function [A]", values["Current [A]"].data),
+    pybop.Dataset("Terminal voltage [V]", CorruptValues),
+]
+
+# Generate problem, cost function, and optimisation class
+problem = pybop.Problem(model, parameters, dataset)
+cost = pybop.SumSquaredError(problem)
+optim = pybop.Optimisation(cost, optimiser=pybop.PSO)
+optim.set_max_iterations(100)
+
+x, final_cost = optim.run()
+print("Estimated parameters:", x)
+
+# Show the generated data
+simulated_values = problem.evaluate(x)
+
+plt.figure(dpi=100)
+plt.xlabel("Time", fontsize=12)
+plt.ylabel("Values", fontsize=12)
+plt.plot(t_eval, CorruptValues, label="Measured")
+plt.fill_between(t_eval, simulated_values - sigma, simulated_values + sigma, alpha=0.2)
+plt.plot(t_eval, simulated_values, label="Simulated")
+plt.legend(bbox_to_anchor=(0.6, 1), loc="upper left", fontsize=12)
+plt.tick_params(axis="both", labelsize=12)
+plt.show()

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,15 @@ def unit(session):
 def coverage(session):
     session.run_always("pip", "install", "-e", ".")
     session.install("pytest-cov")
-    session.run("pytest", "--unit", "-v", "--cov", "--cov-report=xml", "--showlocals")
+    session.run(
+        "pytest",
+        "--unit",
+        "--examples",
+        "-v",
+        "--cov",
+        "--cov-report=xml",
+        "--showlocals",
+    )
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,14 +8,14 @@ nox.options.reuse_existing_virtualenvs = True
 def unit(session):
     session.run_always("pip", "install", "-e", ".")
     session.install("pytest")
-    session.run("pytest", "--unit", "-v")
+    session.run("pytest", "--unit", "-v", "--showlocals")
 
 
 @nox.session
 def coverage(session):
     session.run_always("pip", "install", "-e", ".")
     session.install("pytest-cov")
-    session.run("pytest", "--unit", "-v", "--cov", "--cov-report=xml")
+    session.run("pytest", "--unit", "-v", "--cov", "--cov-report=xml", "--showlocals")
 
 
 @nox.session

--- a/pybop/__init__.py
+++ b/pybop/__init__.py
@@ -50,7 +50,15 @@ from .optimisation import Optimisation
 from .optimisers.base_optimiser import BaseOptimiser
 from .optimisers.nlopt_optimize import NLoptOptimize
 from .optimisers.scipy_minimize import SciPyMinimize
-from .optimisers.pints_optimisers import GradientDescent, Adam, CMAES, IRPropMin, PSO, SNES, XNES
+from .optimisers.pints_optimisers import (
+    GradientDescent,
+    Adam,
+    CMAES,
+    IRPropMin,
+    PSO,
+    SNES,
+    XNES,
+)
 
 #
 # Parameter classes

--- a/pybop/__init__.py
+++ b/pybop/__init__.py
@@ -50,7 +50,7 @@ from .optimisation import Optimisation
 from .optimisers.base_optimiser import BaseOptimiser
 from .optimisers.nlopt_optimize import NLoptOptimize
 from .optimisers.scipy_minimize import SciPyMinimize
-from .optimisers.pints_optimisers import GradientDescent, CMAES
+from .optimisers.pints_optimisers import GradientDescent, Adam, CMAES, IRPropMin, PSO, SNES, XNES
 
 #
 # Parameter classes

--- a/pybop/optimisers/pints_optimisers.py
+++ b/pybop/optimisers/pints_optimisers.py
@@ -4,19 +4,99 @@ import pints
 class GradientDescent(pints.GradientDescent):
     """
     Gradient descent optimiser. Inherits from the PINTS gradient descent class.
+    https://github.com/pints-team/pints/blob/main/pints/_optimisers/_gradient_descent.py
     """
 
     def __init__(self, x0, sigma0=0.1, bounds=None):
         if bounds is not None:
             print("Boundaries ignored by GradientDescent")
 
-        boundaries = None  # Bounds ignored in pints.GradDesc
-        super().__init__(x0, sigma0, boundaries)
+        self.boundaries = None  # Bounds ignored in pints.GradDesc
+        super().__init__(x0, sigma0, self.boundaries)
+
+
+class Adam(pints.Adam):
+    """
+    Adam optimiser. Inherits from the PINTS Adam class.
+    https://github.com/pints-team/pints/blob/main/pints/_optimisers/_adam.py
+    """
+
+    def __init__(self, x0, sigma0=0.1, bounds=None):
+        if bounds is not None:
+            print("Boundaries ignored by Adam")
+
+        self.boundaries = None  # Bounds ignored in pints.Adam
+        super().__init__(x0, sigma0, self.boundaries)
+
+
+class IRPropMin(pints.IRPropMin):
+    """
+    IRProp- optimiser. Inherits from the PINTS IRPropMinus class.
+    https://github.com/pints-team/pints/blob/main/pints/_optimisers/_irpropmin.py
+    """
+
+    def __init__(self, x0, sigma0=0.1, bounds=None):
+        if bounds is not None:
+            self.boundaries = pints.RectangularBoundaries(
+                bounds["lower"], bounds["upper"]
+            )
+        else:
+            self.boundaries = None
+        super().__init__(x0, sigma0, self.boundaries)
+
+
+class PSO(pints.PSO):
+    """
+    Particle swarm optimiser. Inherits from the PINTS PSO class.
+    https://github.com/pints-team/pints/blob/main/pints/_optimisers/_pso.py
+    """
+
+    def __init__(self, x0, sigma0=0.1, bounds=None):
+        if bounds is not None:
+            self.boundaries = pints.RectangularBoundaries(
+                bounds["lower"], bounds["upper"]
+            )
+        else:
+            self.boundaries = None
+        super().__init__(x0, sigma0, self.boundaries)
+
+
+class SNES(pints.SNES):
+    """
+    Stochastic natural evolution strategy optimiser. Inherits from the PINTS SNES class.
+    https://github.com/pints-team/pints/blob/main/pints/_optimisers/_snes.py
+    """
+
+    def __init__(self, x0, sigma0=0.1, bounds=None):
+        if bounds is not None:
+            self.boundaries = pints.RectangularBoundaries(
+                bounds["lower"], bounds["upper"]
+            )
+        else:
+            self.boundaries = None
+        super().__init__(x0, sigma0, self.boundaries)
+
+
+class XNES(pints.XNES):
+    """
+    Exponential natural evolution strategy optimiser. Inherits from the PINTS XNES class.
+    https://github.com/pints-team/pints/blob/main/pints/_optimisers/_xnes.py
+    """
+
+    def __init__(self, x0, sigma0=0.1, bounds=None):
+        if bounds is not None:
+            self.boundaries = pints.RectangularBoundaries(
+                bounds["lower"], bounds["upper"]
+            )
+        else:
+            self.boundaries = None
+        super().__init__(x0, sigma0, self.boundaries)
 
 
 class CMAES(pints.CMAES):
     """
     Class for the PINTS optimisation. Extends the BaseOptimiser class.
+    https://github.com/pints-team/pints/blob/main/pints/_optimisers/_cmaes.py
     """
 
     def __init__(self, x0, sigma0=0.1, bounds=None):

--- a/tests/unit/test_examples.py
+++ b/tests/unit/test_examples.py
@@ -9,7 +9,7 @@ class TestExamples:
     A class to test the example scripts.
     """
 
-    @pytest.mark.unit
+    @pytest.mark.examples
     def test_example_scripts(self):
         path_to_example_scripts = os.path.join(
             pybop.script_path, "..", "examples", "scripts"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -34,7 +34,7 @@ class TestModels:
 
     @pytest.mark.unit
     def test_predict_with_inputs(self):
-        # Define model
+        # Define SPM
         model = pybop.lithium_ion.SPM()
         t_eval = np.linspace(0, 10, 100)
         inputs = {
@@ -42,6 +42,11 @@ class TestModels:
             "Positive electrode active material volume fraction": 0.63,
         }
 
+        res = model.predict(t_eval=t_eval, inputs=inputs)
+        assert len(res["Terminal voltage [V]"].data) == 100
+
+        # Define SPMe
+        model = pybop.lithium_ion.SPMe()
         res = model.predict(t_eval=t_eval, inputs=inputs)
         assert len(res["Terminal voltage [V]"].data) == 100
 

--- a/tests/unit/test_optimisation.py
+++ b/tests/unit/test_optimisation.py
@@ -9,32 +9,17 @@ class TestOptimisation:
     A class to test the optimisation class.
     """
 
-    @pytest.mark.unit
-    def test_standalone(self):
-        # Build an Optimisation problem with a StandaloneCost
-        cost = StandaloneCost()
-
-        opt = pybop.Optimisation(cost=cost, optimiser=pybop.NLoptOptimize)
-
-        assert len(opt.x0) == opt.n_parameters
-
-        x, final_cost = opt.run()
-
-        np.testing.assert_allclose(x, 0, atol=1e-2)
-        np.testing.assert_allclose(final_cost, 42, atol=1e-2)
-
-    @pytest.mark.unit
-    def test_prior_sampling(self):
-        # Tests prior sampling
-        model = pybop.lithium_ion.SPM()
-
-        dataset = [
-            pybop.Dataset("Time [s]", np.linspace(0, 3600, 100)),
-            pybop.Dataset("Current function [A]", np.zeros(100)),
-            pybop.Dataset("Terminal voltage [V]", np.ones(100)),
+    @pytest.fixture
+    def dataset(self):
+        return [
+            pybop.Dataset("Time [s]", np.linspace(0, 360, 10)),
+            pybop.Dataset("Current function [A]", np.zeros(10)),
+            pybop.Dataset("Terminal voltage [V]", np.ones(10)),
         ]
 
-        param = [
+    @pytest.fixture
+    def parameters(self):
+        return [
             pybop.Parameter(
                 "Negative electrode active material volume fraction",
                 prior=pybop.Gaussian(0.75, 0.2),
@@ -42,95 +27,88 @@ class TestOptimisation:
             )
         ]
 
-        signal = "Terminal voltage [V]"
-        problem = pybop.Problem(model, param, dataset, signal=signal)
-        cost = pybop.RootMeanSquaredError(problem)
+    @pytest.fixture
+    def problem(self, parameters, dataset):
+        return pybop.Problem(
+            pybop.lithium_ion.SPM(), parameters, dataset, signal="Terminal voltage [V]"
+        )
 
+    @pytest.fixture
+    def cost(self, problem):
+        return pybop.SumSquaredError(problem)
+
+    @pytest.mark.parametrize(
+        "optimiser_class, expected_name",
+        [
+            (pybop.NLoptOptimize, "NLoptOptimize"),
+            (pybop.SciPyMinimize, "SciPyMinimize"),
+            (pybop.GradientDescent, "Gradient descent"),
+            (pybop.Adam, "Adam"),
+            (pybop.CMAES, "Covariance Matrix Adaptation Evolution Strategy (CMA-ES)"),
+            (pybop.SNES, "Seperable Natural Evolution Strategy (SNES)"),
+            (pybop.XNES, "Exponential Natural Evolution Strategy (xNES)"),
+            (pybop.PSO, "Particle Swarm Optimisation (PSO)"),
+            (pybop.IRPropMin, "iRprop-"),
+        ],
+    )
+    @pytest.mark.unit
+    def test_optimiser_classes(self, cost, optimiser_class, expected_name):
+        if optimiser_class not in [pybop.NLoptOptimize, pybop.SciPyMinimize]:
+            cost.bounds = None
+            opt = pybop.Optimisation(cost=cost, optimiser=optimiser_class)
+            assert opt.optimiser.boundaries is None
+            assert opt.optimiser.name() == expected_name
+        else:
+            opt = pybop.Optimisation(cost=cost, optimiser=optimiser_class)
+            assert opt.optimiser.name == expected_name
+
+        assert opt.optimiser is not None
+        if optimiser_class == pybop.NLoptOptimize:
+            assert opt.optimiser.n_param == 1
+
+    @pytest.mark.unit
+    def test_default_optimiser_with_bounds(self, cost):
+        opt = pybop.Optimisation(cost=cost)
+        assert (
+            opt.optimiser.name()
+            == "Covariance Matrix Adaptation Evolution Strategy (CMA-ES)"
+        )
+
+    @pytest.mark.unit
+    def test_default_optimiser_no_bounds(self, cost):
+        cost.bounds = None
+        opt = pybop.Optimisation(cost=cost)
+        assert opt.optimiser.boundaries is None
+
+    @pytest.mark.unit
+    def test_incorrect_optimiser_class(self, cost):
+        class RandomClass:
+            pass
+
+        with pytest.raises(ValueError):
+            pybop.Optimisation(cost=cost, optimiser=RandomClass)
+
+    @pytest.mark.unit
+    def test_standalone(self):
+        # Build an Optimisation problem with a StandaloneCost
+        cost = StandaloneCost()
+        opt = pybop.Optimisation(cost=cost, optimiser=pybop.NLoptOptimize)
+        x, final_cost = opt.run()
+
+        assert len(opt.x0) == opt.n_parameters
+        np.testing.assert_allclose(x, 0, atol=1e-2)
+        np.testing.assert_allclose(final_cost, 42, atol=1e-2)
+
+    @pytest.mark.unit
+    def test_prior_sampling(self, cost):
+        # Tests prior sampling
         for i in range(50):
             opt = pybop.Optimisation(cost=cost, optimiser=pybop.NLoptOptimize)
 
             assert opt.x0 <= 0.77 and opt.x0 >= 0.73
 
     @pytest.mark.unit
-    def test_optimiser_construction(self):
-        # Tests construction of optimisers
-
-        dataset = [
-            pybop.Dataset("Time [s]", np.linspace(0, 360, 10)),
-            pybop.Dataset("Current function [A]", np.zeros(10)),
-            pybop.Dataset("Terminal voltage [V]", np.ones(10)),
-        ]
-        parameters = [
-            pybop.Parameter(
-                "Negative electrode active material volume fraction",
-                prior=pybop.Gaussian(0.75, 0.2),
-                bounds=[0.73, 0.77],
-            )
-        ]
-
-        problem = pybop.Problem(
-            pybop.lithium_ion.SPM(), parameters, dataset, signal="Terminal voltage [V]"
-        )
-        cost = pybop.SumSquaredError(problem)
-
-        # Test construction of optimisers
-        # NLopt
-        opt = pybop.Optimisation(cost=cost, optimiser=pybop.NLoptOptimize)
-        assert opt.optimiser is not None
-        assert opt.optimiser.name == "NLoptOptimize"
-        assert opt.optimiser.n_param == 1
-
-        # Gradient Descent
-        opt = pybop.Optimisation(cost=cost, optimiser=pybop.GradientDescent)
-        assert opt.optimiser is not None
-
-        # None
-        opt = pybop.Optimisation(cost=cost)
-        assert opt.optimiser is not None
-        assert (
-            opt.optimiser.name()
-            == "Covariance Matrix Adaptation Evolution Strategy (CMA-ES)"
-        )
-
-        # None with no bounds
-        cost.bounds = None
-        opt = pybop.Optimisation(cost=cost)
-        assert opt.optimiser.boundaries is None
-
-        # SciPy
-        opt = pybop.Optimisation(cost=cost, optimiser=pybop.SciPyMinimize)
-        assert opt.optimiser is not None
-        assert opt.optimiser.name == "SciPyMinimize"
-
-        # Incorrect class
-        class randomclass:
-            pass
-
-        with pytest.raises(ValueError):
-            pybop.Optimisation(cost=cost, optimiser=randomclass)
-
-    @pytest.mark.unit
-    def test_halting(self):
-        # Tests halting criteria
-        model = pybop.lithium_ion.SPM()
-
-        dataset = [
-            pybop.Dataset("Time [s]", np.linspace(0, 3600, 100)),
-            pybop.Dataset("Current function [A]", np.zeros(100)),
-            pybop.Dataset("Terminal voltage [V]", np.ones(100)),
-        ]
-
-        param = [
-            pybop.Parameter(
-                "Negative electrode active material volume fraction",
-                prior=pybop.Gaussian(0.75, 0.2),
-                bounds=[0.73, 0.77],
-            )
-        ]
-
-        problem = pybop.Problem(model, param, dataset, signal="Terminal voltage [V]")
-        cost = pybop.SumSquaredError(problem)
-
+    def test_halting(self, cost):
         # Test max evalutions
         optim = pybop.Optimisation(cost=cost, optimiser=pybop.GradientDescent)
         optim.set_max_evaluations(10)


### PR DESCRIPTION
Closes #116. Adds the remaining Pints' optimiser methods, and updates examples. 

I've left `_nelder-mead.py` and `_cmaes_bare.py` out of this PR, as we have access to the former via SciPy and I don't believe we need two CMAES methods for the latter.