### PR TITLE
Adds Thevenin model

### DIFF
--- a/examples/scripts/ecm_CMAES.py
+++ b/examples/scripts/ecm_CMAES.py
@@ -2,19 +2,18 @@ import pybop
 import numpy as np
 import matplotlib.pyplot as plt
 
-# parameter_set = pybop.ParameterSet("pybamm", "Chen2020")
-model = pybop.empirical.Thevenin()
+model = pybop.empirical.Thevenin()  # (options={"number of rc elements": 2})
 
 # Fitting parameters
 parameters = [
     pybop.Parameter(
         "R0 [Ohm]",
-        prior=pybop.Gaussian(0.001, 0.0001),
-        bounds=[1e-5, 1e-2],
+        prior=pybop.Gaussian(0.0002, 0.0001),
+        bounds=[1e-4, 1e-2],
     ),
     pybop.Parameter(
         "R1 [Ohm]",
-        prior=pybop.Gaussian(0.001, 0.0001),
+        prior=pybop.Gaussian(0.0001, 0.0001),
         bounds=[1e-5, 1e-2],
     ),
 ]
@@ -22,14 +21,12 @@ parameters = [
 sigma = 0.001
 t_eval = np.arange(0, 900, 2)
 values = model.predict(t_eval=t_eval)
-CorruptValues = values["Battery voltage [V]"].data + np.random.normal(
-    0, sigma, len(t_eval)
-)
+CorruptValues = values["Voltage [V]"].data + np.random.normal(0, sigma, len(t_eval))
 
 dataset = [
     pybop.Dataset("Time [s]", t_eval),
     pybop.Dataset("Current function [A]", values["Current [A]"].data),
-    pybop.Dataset("Battery voltage [V]", CorruptValues),
+    pybop.Dataset("Voltage [V]", CorruptValues),
 ]
 
 # Generate problem, cost function, and optimisation class

--- a/examples/scripts/ecm_CMAES.py
+++ b/examples/scripts/ecm_CMAES.py
@@ -2,7 +2,38 @@ import pybop
 import numpy as np
 import matplotlib.pyplot as plt
 
-model = pybop.empirical.Thevenin()  # (options={"number of rc elements": 2})
+# Define the initial parameter set
+params = {
+    "chemistry": "ecm",
+    "Initial SoC": 0.5,
+    "Initial temperature [K]": 25 + 273.15,
+    "Cell capacity [A.h]": 5,
+    "Nominal cell capacity [A.h]": 5,
+    "Ambient temperature [K]": 25 + 273.15,
+    "Current function [A]": 5,
+    "Upper voltage cut-off [V]": 4.2,
+    "Lower voltage cut-off [V]": 3.0,
+    "Cell thermal mass [J/K]": 1000,
+    "Cell-jig heat transfer coefficient [W/K]": 10,
+    "Jig thermal mass [J/K]": 500,
+    "Jig-air heat transfer coefficient [W/K]": 10,
+    "Open-circuit voltage [V]": pybop.empirical.Thevenin().default_parameter_values[
+        "Open-circuit voltage [V]"
+    ],
+    "R0 [Ohm]": 0.001,
+    "Element-1 initial overpotential [V]": 0,
+    "Element-2 initial overpotential [V]": 0,
+    "R1 [Ohm]": 0.0002,
+    "R2 [Ohm]": 0.0003,
+    "C1 [F]": 10000,
+    "C2 [F]": 5000,
+    "Entropic change [V/K]": 0.0004,
+}
+
+# Define the model
+model = pybop.empirical.Thevenin(
+    parameter_set=params, options={"number of rc elements": 2}
+)
 
 # Fitting parameters
 parameters = [

--- a/examples/scripts/ecm_CMAES.py
+++ b/examples/scripts/ecm_CMAES.py
@@ -1,0 +1,55 @@
+import pybop
+import numpy as np
+import matplotlib.pyplot as plt
+
+# parameter_set = pybop.ParameterSet("pybamm", "Chen2020")
+model = pybop.empirical.Thevenin()
+
+# Fitting parameters
+parameters = [
+    pybop.Parameter(
+        "R0 [Ohm]",
+        prior=pybop.Gaussian(0.001, 0.0001),
+        bounds=[1e-5, 1e-2],
+    ),
+    pybop.Parameter(
+        "R1 [Ohm]",
+        prior=pybop.Gaussian(0.001, 0.0001),
+        bounds=[1e-5, 1e-2],
+    ),
+]
+
+sigma = 0.001
+t_eval = np.arange(0, 900, 2)
+values = model.predict(t_eval=t_eval)
+CorruptValues = values["Battery voltage [V]"].data + np.random.normal(
+    0, sigma, len(t_eval)
+)
+
+dataset = [
+    pybop.Dataset("Time [s]", t_eval),
+    pybop.Dataset("Current function [A]", values["Current [A]"].data),
+    pybop.Dataset("Battery voltage [V]", CorruptValues),
+]
+
+# Generate problem, cost function, and optimisation class
+problem = pybop.Problem(model, parameters, dataset)
+cost = pybop.SumSquaredError(problem)
+optim = pybop.Optimisation(cost, optimiser=pybop.CMAES)
+optim.set_max_iterations(100)
+
+x, final_cost = optim.run()
+print("Estimated parameters:", x)
+
+# Show the generated data
+simulated_values = problem.evaluate(x)
+
+plt.figure(dpi=100)
+plt.xlabel("Time", fontsize=12)
+plt.ylabel("Values", fontsize=12)
+plt.plot(t_eval, CorruptValues, label="Measured")
+plt.fill_between(t_eval, simulated_values - sigma, simulated_values + sigma, alpha=0.2)
+plt.plot(t_eval, simulated_values, label="Simulated")
+plt.legend(bbox_to_anchor=(0.6, 1), loc="upper left", fontsize=12)
+plt.tick_params(axis="both", labelsize=12)
+plt.show()

--- a/examples/scripts/spm_CMAES.py
+++ b/examples/scripts/spm_CMAES.py
@@ -22,14 +22,12 @@ parameters = [
 sigma = 0.001
 t_eval = np.arange(0, 900, 2)
 values = model.predict(t_eval=t_eval)
-CorruptValues = values["Terminal voltage [V]"].data + np.random.normal(
-    0, sigma, len(t_eval)
-)
+CorruptValues = values["Voltage [V]"].data + np.random.normal(0, sigma, len(t_eval))
 
 dataset = [
     pybop.Dataset("Time [s]", t_eval),
     pybop.Dataset("Current function [A]", values["Current [A]"].data),
-    pybop.Dataset("Terminal voltage [V]", CorruptValues),
+    pybop.Dataset("Voltage [V]", CorruptValues),
 ]
 
 # Generate problem, cost function, and optimisation class

--- a/examples/scripts/spm_IRPropMin.py
+++ b/examples/scripts/spm_IRPropMin.py
@@ -22,14 +22,12 @@ parameters = [
 sigma = 0.001
 t_eval = np.arange(0, 900, 2)
 values = model.predict(t_eval=t_eval)
-CorruptValues = values["Terminal voltage [V]"].data + np.random.normal(
-    0, sigma, len(t_eval)
-)
+CorruptValues = values["Voltage [V]"].data + np.random.normal(0, sigma, len(t_eval))
 
 dataset = [
     pybop.Dataset("Time [s]", t_eval),
     pybop.Dataset("Current function [A]", values["Current [A]"].data),
-    pybop.Dataset("Terminal voltage [V]", CorruptValues),
+    pybop.Dataset("Voltage [V]", CorruptValues),
 ]
 
 # Generate problem, cost function, and optimisation class

--- a/examples/scripts/spm_SNES.py
+++ b/examples/scripts/spm_SNES.py
@@ -22,14 +22,12 @@ parameters = [
 sigma = 0.001
 t_eval = np.arange(0, 900, 2)
 values = model.predict(t_eval=t_eval)
-CorruptValues = values["Terminal voltage [V]"].data + np.random.normal(
-    0, sigma, len(t_eval)
-)
+CorruptValues = values["Voltage [V]"].data + np.random.normal(0, sigma, len(t_eval))
 
 dataset = [
     pybop.Dataset("Time [s]", t_eval),
     pybop.Dataset("Current function [A]", values["Current [A]"].data),
-    pybop.Dataset("Terminal voltage [V]", CorruptValues),
+    pybop.Dataset("Voltage [V]", CorruptValues),
 ]
 
 # Generate problem, cost function, and optimisation class

--- a/examples/scripts/spm_XNES.py
+++ b/examples/scripts/spm_XNES.py
@@ -22,14 +22,12 @@ parameters = [
 sigma = 0.001
 t_eval = np.arange(0, 900, 2)
 values = model.predict(t_eval=t_eval)
-CorruptValues = values["Terminal voltage [V]"].data + np.random.normal(
-    0, sigma, len(t_eval)
-)
+CorruptValues = values["Voltage [V]"].data + np.random.normal(0, sigma, len(t_eval))
 
 dataset = [
     pybop.Dataset("Time [s]", t_eval),
     pybop.Dataset("Current function [A]", values["Current [A]"].data),
-    pybop.Dataset("Terminal voltage [V]", CorruptValues),
+    pybop.Dataset("Voltage [V]", CorruptValues),
 ]
 
 # Generate problem, cost function, and optimisation class

--- a/examples/scripts/spm_adam.py
+++ b/examples/scripts/spm_adam.py
@@ -24,15 +24,13 @@ parameters = [
 sigma = 0.001
 t_eval = np.arange(0, 900, 2)
 values = model.predict(t_eval=t_eval)
-corrupt_values = values["Terminal voltage [V]"].data + np.random.normal(
-    0, sigma, len(t_eval)
-)
+corrupt_values = values["Voltage [V]"].data + np.random.normal(0, sigma, len(t_eval))
 
 # Dataset definition
 dataset = [
     pybop.Dataset("Time [s]", t_eval),
     pybop.Dataset("Current function [A]", values["Current [A]"].data),
-    pybop.Dataset("Terminal voltage [V]", corrupt_values),
+    pybop.Dataset("Voltage [V]", corrupt_values),
 ]
 
 # Generate problem, cost function, and optimisation class

--- a/examples/scripts/spm_descent.py
+++ b/examples/scripts/spm_descent.py
@@ -24,15 +24,13 @@ parameters = [
 sigma = 0.001
 t_eval = np.arange(0, 900, 2)
 values = model.predict(t_eval=t_eval)
-corrupt_values = values["Terminal voltage [V]"].data + np.random.normal(
-    0, sigma, len(t_eval)
-)
+corrupt_values = values["Voltage [V]"].data + np.random.normal(0, sigma, len(t_eval))
 
 # Dataset definition
 dataset = [
     pybop.Dataset("Time [s]", t_eval),
     pybop.Dataset("Current function [A]", values["Current [A]"].data),
-    pybop.Dataset("Terminal voltage [V]", corrupt_values),
+    pybop.Dataset("Voltage [V]", corrupt_values),
 ]
 
 # Generate problem, cost function, and optimisation class

--- a/examples/scripts/spm_nlopt.py
+++ b/examples/scripts/spm_nlopt.py
@@ -7,7 +7,7 @@ Measurements = pd.read_csv("examples/scripts/Chen_example.csv", comment="#").to_
 dataset = [
     pybop.Dataset("Time [s]", Measurements[:, 0]),
     pybop.Dataset("Current function [A]", Measurements[:, 1]),
-    pybop.Dataset("Terminal voltage [V]", Measurements[:, 2]),
+    pybop.Dataset("Voltage [V]", Measurements[:, 2]),
 ]
 
 # Define model
@@ -31,7 +31,7 @@ parameters = [
 ]
 
 # Define the cost to optimise
-signal = "Terminal voltage [V]"
+signal = "Voltage [V]"
 problem = pybop.Problem(model, parameters, dataset, signal=signal, init_soc=0.98)
 cost = pybop.RootMeanSquaredError(problem)
 

--- a/examples/scripts/spm_pso.py
+++ b/examples/scripts/spm_pso.py
@@ -22,14 +22,12 @@ parameters = [
 sigma = 0.001
 t_eval = np.arange(0, 900, 2)
 values = model.predict(t_eval=t_eval)
-CorruptValues = values["Terminal voltage [V]"].data + np.random.normal(
-    0, sigma, len(t_eval)
-)
+CorruptValues = values["Voltage [V]"].data + np.random.normal(0, sigma, len(t_eval))
 
 dataset = [
     pybop.Dataset("Time [s]", t_eval),
     pybop.Dataset("Current function [A]", values["Current [A]"].data),
-    pybop.Dataset("Terminal voltage [V]", CorruptValues),
+    pybop.Dataset("Voltage [V]", CorruptValues),
 ]
 
 # Generate problem, cost function, and optimisation class

--- a/pybop/__init__.py
+++ b/pybop/__init__.py
@@ -38,6 +38,7 @@ from .datasets.base_dataset import Dataset
 #
 from .models.base_model import BaseModel
 from .models import lithium_ion
+from .models import empirical
 
 #
 # Main optimisation class

--- a/pybop/_problem.py
+++ b/pybop/_problem.py
@@ -11,7 +11,7 @@ class Problem:
         model,
         parameters,
         dataset,
-        signal="Battery voltage [V]",
+        signal="Voltage [V]",
         check_model=True,
         init_soc=None,
         x0=None,

--- a/pybop/_problem.py
+++ b/pybop/_problem.py
@@ -11,7 +11,7 @@ class Problem:
         model,
         parameters,
         dataset,
-        signal="Terminal voltage [V]",
+        signal="Battery voltage [V]",
         check_model=True,
         init_soc=None,
         x0=None,

--- a/pybop/models/empirical/__init__.py
+++ b/pybop/models/empirical/__init__.py
@@ -1,0 +1,4 @@
+#
+# Import lithium ion based models
+#
+from .base_ecm import Thevenin

--- a/pybop/models/empirical/base_ecm.py
+++ b/pybop/models/empirical/base_ecm.py
@@ -27,10 +27,15 @@ class Thevenin(BaseModel):
         self._unprocessed_model = self.pybamm_model
         self.name = name
 
-        self.default_parameter_values = self.pybamm_model.default_parameter_values
-        self._parameter_set = (
-            parameter_set or self.pybamm_model.default_parameter_values
-        )
+        if isinstance(parameter_set, dict):
+            self.default_parameter_values = pybamm.ParameterValues(parameter_set)
+            self._parameter_set = self.default_parameter_values
+        else:
+            self.default_parameter_values = self.pybamm_model.default_parameter_values
+            self._parameter_set = (
+                parameter_set or self.pybamm_model.default_parameter_values
+            )
+
         self._unprocessed_parameter_set = self._parameter_set
 
         self.geometry = geometry or self.pybamm_model.default_geometry

--- a/pybop/models/empirical/base_ecm.py
+++ b/pybop/models/empirical/base_ecm.py
@@ -1,0 +1,48 @@
+import pybamm
+from ..base_model import BaseModel
+
+
+class Thevenin(BaseModel):
+    """
+    Composition of the PyBaMM Single Particle Model class.
+
+    """
+
+    def __init__(
+        self,
+        name="Equivalent Circuit Thevenin Model",
+        parameter_set=None,
+        geometry=None,
+        submesh_types=None,
+        var_pts=None,
+        spatial_methods=None,
+        solver=None,
+        options=None,
+        **kwargs,
+    ):
+        super().__init__()
+        self.pybamm_model = pybamm.equivalent_circuit.Thevenin(
+            options=options, **kwargs
+        )
+        self._unprocessed_model = self.pybamm_model
+        self.name = name
+
+        self.default_parameter_values = self.pybamm_model.default_parameter_values
+        self._parameter_set = (
+            parameter_set or self.pybamm_model.default_parameter_values
+        )
+        self._unprocessed_parameter_set = self._parameter_set
+
+        self.geometry = geometry or self.pybamm_model.default_geometry
+        self.submesh_types = submesh_types or self.pybamm_model.default_submesh_types
+        self.var_pts = var_pts or self.pybamm_model.default_var_pts
+        self.spatial_methods = (
+            spatial_methods or self.pybamm_model.default_spatial_methods
+        )
+        self.solver = solver or self.pybamm_model.default_solver
+
+        self._model_with_set_params = None
+        self._built_model = None
+        self._built_initial_soc = None
+        self._mesh = None
+        self._disc = None

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/pybop-team/PyBOP",
     install_requires=[
-        "pybamm>=23.1",
+        "pybamm>=23.5",
         "numpy>=1.16",
         "scipy>=1.3",
         "pandas>=1.0",


### PR DESCRIPTION
This PR adds `pybop.empirical.Thevenin()`. This class follows the PyBOP standard for including PyBaMM models by composing the `pybamm.equivalent_circuit.Thevenin()` class.

The checklist for this PR is as follows,

- [X] Adds method for import ECM parameters
- [X] Updates problems' signal defintion for alignment across `pybop.lithium_ion` and `pybop.empirical` models
- [X] Updates PyBaMM version dependency for the signal change to "Voltage [V]" as per [[1]](https://github.com/pybamm-team/PyBaMM/blob/ebacf496a4322b084b7c4058599755b45008283b/CHANGELOG.md#features-4)
- [ ] Adds corresponding tests and updates changelog

Closes #107 