### PR TITLE
Docs site version switcher update.

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,12 +1,12 @@
 [
     {
       "version": "latest",
-      "url": "https://pybop-docs.readthedocs.io/en/latest/",
-      "preferred": true
+      "url": "https://pybop-docs.readthedocs.io/en/latest/"
     },
     {
-      "name": "v23.11 (stable)",
-      "version": "v23.11",
-      "url": "https://pybop-docs.readthedocs.io/en/latest/"
+      "name": "v23.12 (stable)",
+      "version": "v23.12",
+      "url": "https://pybop-docs.readthedocs.io/en/v23.12/",
+      "preferred": true
     }
   ]


### PR DESCRIPTION
For future reference, this needs to be updated with release tags and will be captured in #157. Closes. #158.