### PR TITLE
Revert `np.inf` return for non-physical optimisation locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Bug Fixes
 
+- [#164](https://github.com/pybop-team/PyBOP/issues/164) - Fixes convergence issues with gradient-based optimisers, changes default `model.check_params()` to allow infeasible solutions during optimisation iterations. Adds a feasibility check on the optimal parameters.
+
 # [v23.12](https://github.com/pybop-team/PyBOP/tree/v23.12) - 2023-12-19
 ## Features
 

--- a/examples/scripts/spm_XNES.py
+++ b/examples/scripts/spm_XNES.py
@@ -9,12 +9,12 @@ model = pybop.lithium_ion.SPM(parameter_set=parameter_set)
 parameters = [
     pybop.Parameter(
         "Negative electrode active material volume fraction",
-        prior=pybop.Gaussian(0.6, 0.05),
+        prior=pybop.Gaussian(0.68, 0.05),
         bounds=[0.5, 0.8],
     ),
     pybop.Parameter(
         "Positive electrode active material volume fraction",
-        prior=pybop.Gaussian(0.48, 0.05),
+        prior=pybop.Gaussian(0.58, 0.05),
         bounds=[0.4, 0.7],
     ),
 ]

--- a/examples/scripts/spm_adam.py
+++ b/examples/scripts/spm_adam.py
@@ -9,12 +9,12 @@ model = pybop.lithium_ion.SPMe(parameter_set=parameter_set)
 parameters = [
     pybop.Parameter(
         "Negative electrode active material volume fraction",
-        prior=pybop.Gaussian(0.6, 0.05),
+        prior=pybop.Gaussian(0.68, 0.05),
         bounds=[0.5, 0.8],
     ),
     pybop.Parameter(
         "Positive electrode active material volume fraction",
-        prior=pybop.Gaussian(0.48, 0.05),
+        prior=pybop.Gaussian(0.58, 0.05),
         bounds=[0.4, 0.7],
     ),
 ]
@@ -37,7 +37,7 @@ dataset = pybop.Dataset(
 # Generate problem, cost function, and optimisation class
 problem = pybop.FittingProblem(model, parameters, dataset)
 cost = pybop.SumSquaredError(problem)
-optim = pybop.Optimisation(cost, optimiser=pybop.Adam)
+optim = pybop.Optimisation(cost, optimiser=pybop.Adam, verbose=True)
 optim.set_max_iterations(100)
 
 # Run optimisation

--- a/examples/scripts/spm_descent.py
+++ b/examples/scripts/spm_descent.py
@@ -9,12 +9,12 @@ model = pybop.lithium_ion.SPMe(parameter_set=parameter_set)
 parameters = [
     pybop.Parameter(
         "Negative electrode active material volume fraction",
-        prior=pybop.Gaussian(0.6, 0.05),
+        prior=pybop.Gaussian(0.68, 0.05),
         bounds=[0.5, 0.8],
     ),
     pybop.Parameter(
         "Positive electrode active material volume fraction",
-        prior=pybop.Gaussian(0.48, 0.05),
+        prior=pybop.Gaussian(0.58, 0.05),
         bounds=[0.4, 0.7],
     ),
 ]
@@ -37,9 +37,10 @@ dataset = pybop.Dataset(
 # Generate problem, cost function, and optimisation class
 problem = pybop.FittingProblem(model, parameters, dataset)
 cost = pybop.SumSquaredError(problem)
-optim = pybop.Optimisation(cost, optimiser=pybop.GradientDescent)
-optim.optimiser.set_learning_rate(0.025)
-optim.set_max_iterations(100)
+optim = pybop.Optimisation(
+    cost, optimiser=pybop.GradientDescent, sigma0=0.022, verbose=True
+)
+optim.set_max_iterations(125)
 
 # Run optimisation
 x, final_cost = optim.run()

--- a/examples/scripts/spme_max_energy.py
+++ b/examples/scripts/spme_max_energy.py
@@ -176,7 +176,9 @@ class GravimetricEnergyDensity(pybop.BaseCost):
 
 # Generate cost function and optimisation class
 cost = GravimetricEnergyDensity(problem)
-optim = pybop.Optimisation(cost, optimiser=pybop.PSO, verbose=True)
+optim = pybop.Optimisation(
+    cost, optimiser=pybop.PSO, verbose=True, infeasible_locations=False
+)
 optim.set_max_iterations(5)
 
 # Run optimisation

--- a/examples/scripts/spme_max_energy.py
+++ b/examples/scripts/spme_max_energy.py
@@ -177,7 +177,7 @@ class GravimetricEnergyDensity(pybop.BaseCost):
 # Generate cost function and optimisation class
 cost = GravimetricEnergyDensity(problem)
 optim = pybop.Optimisation(
-    cost, optimiser=pybop.PSO, verbose=True, infeasible_locations=False
+    cost, optimiser=pybop.PSO, verbose=True, allow_infeasible_solutions=False
 )
 optim.set_max_iterations(5)
 

--- a/pybop/_optimisation.py
+++ b/pybop/_optimisation.py
@@ -40,6 +40,7 @@ class Optimisation:
         sigma0=None,
         verbose=False,
         physical_viability=True,
+        infesible_locations=True,
     ):
         self.cost = cost
         self.optimiser = optimiser
@@ -49,10 +50,15 @@ class Optimisation:
         self.n_parameters = cost.n_parameters
         self.sigma0 = sigma0
         self.physical_viability = physical_viability
+        self.infesible_locations = infesible_locations
         self.log = []
 
         # Convert x0 to pints vector
         self._x0 = pints.vector(self.x0)
+
+        # Set Infesible Locations
+        if self.cost.problem is not None:
+            self.cost.problem._model.infesible_locations = self.infesible_locations
 
         # PyBOP doesn't currently support the pints transformation class
         self._transformation = None
@@ -480,7 +486,7 @@ class Optimisation:
         Check if the optimised parameters are physically viable.
         """
 
-        if self.cost.problem._model.check_params(inputs=x, silent=False):
+        if self.cost.problem._model.check_params(inputs=x, infesible_locations=False):
             return
         else:
             warnings.warn(

--- a/pybop/_optimisation.py
+++ b/pybop/_optimisation.py
@@ -20,7 +20,7 @@ class Optimisation:
         If True, the optimization progress is printed (default: False).
     physical_viability : bool, optional
         If True, the feasibility of the optimised parameters is checked (default: True).
-    infeasible_locations : bool, optional
+    allow_infeasible_solutions : bool, optional
         If True, infeasible parameter values will be allowed in the optimisation (default: True).
 
     Attributes
@@ -44,7 +44,7 @@ class Optimisation:
         sigma0=None,
         verbose=False,
         physical_viability=True,
-        infeasible_locations=True,
+        allow_infeasible_solutions=True,
     ):
         self.cost = cost
         self.optimiser = optimiser
@@ -54,7 +54,7 @@ class Optimisation:
         self.n_parameters = cost.n_parameters
         self.sigma0 = sigma0
         self.physical_viability = physical_viability
-        self.infeasible_locations = infeasible_locations
+        self.allow_infeasible_solutions = allow_infeasible_solutions
         self.log = []
 
         # Convert x0 to pints vector
@@ -62,11 +62,13 @@ class Optimisation:
 
         # Set whether to allow infeasible locations
         if self.cost.problem is not None and hasattr(self.cost.problem, "_model"):
-            self.cost.problem._model.infeasible_locations = self.infeasible_locations
+            self.cost.problem._model.allow_infeasible_solutions = (
+                self.allow_infeasible_solutions
+            )
         else:
             # Turn off this feature as there is no model
             self.physical_viability = False
-            self.infeasible_locations = False
+            self.allow_infeasible_solutions = False
 
         # PyBOP doesn't currently support the pints transformation class
         self._transformation = None
@@ -494,12 +496,14 @@ class Optimisation:
         Check if the optimised parameters are physically viable.
         """
 
-        if self.cost.problem._model.check_params(inputs=x, infeasible_locations=False):
+        if self.cost.problem._model.check_params(
+            inputs=x, allow_infeasible_solutions=False
+        ):
             return
         else:
             warnings.warn(
                 "Optimised parameters are not physically viable! \nConsider retrying the optimisation"
-                + " with a non-gradient-based optimiser and the option infeasible_locations=False",
+                + " with a non-gradient-based optimiser and the option allow_infeasible_solutions=False",
                 UserWarning,
                 stacklevel=2,
             )

--- a/pybop/_optimisation.py
+++ b/pybop/_optimisation.py
@@ -40,7 +40,7 @@ class Optimisation:
         sigma0=None,
         verbose=False,
         physical_viability=True,
-        infesible_locations=True,
+        infeasible_locations=True,
     ):
         self.cost = cost
         self.optimiser = optimiser
@@ -50,15 +50,15 @@ class Optimisation:
         self.n_parameters = cost.n_parameters
         self.sigma0 = sigma0
         self.physical_viability = physical_viability
-        self.infesible_locations = infesible_locations
+        self.infeasible_locations = infeasible_locations
         self.log = []
 
         # Convert x0 to pints vector
         self._x0 = pints.vector(self.x0)
 
-        # Set Infesible Locations
+        # Set infeasible Locations
         if self.cost.problem is not None:
-            self.cost.problem._model.infesible_locations = self.infesible_locations
+            self.cost.problem._model.infeasible_locations = self.infeasible_locations
 
         # PyBOP doesn't currently support the pints transformation class
         self._transformation = None
@@ -486,7 +486,7 @@ class Optimisation:
         Check if the optimised parameters are physically viable.
         """
 
-        if self.cost.problem._model.check_params(inputs=x, infesible_locations=False):
+        if self.cost.problem._model.check_params(inputs=x, infeasible_locations=False):
             return
         else:
             warnings.warn(

--- a/pybop/_optimisation.py
+++ b/pybop/_optimisation.py
@@ -1,6 +1,7 @@
 import pybop
 import pints
 import numpy as np
+import warnings
 
 
 class Optimisation:
@@ -38,6 +39,7 @@ class Optimisation:
         optimiser=None,
         sigma0=None,
         verbose=False,
+        physical_viability=True,
     ):
         self.cost = cost
         self.optimiser = optimiser
@@ -46,6 +48,7 @@ class Optimisation:
         self.bounds = cost.bounds
         self.n_parameters = cost.n_parameters
         self.sigma0 = sigma0
+        self.physical_viability = physical_viability
         self.log = []
 
         # Convert x0 to pints vector
@@ -345,6 +348,13 @@ class Optimisation:
         if self._transformation is not None:
             x = self._transformation.to_model(x)
 
+        # Store the optimised parameters
+        self.store_optimised_parameters(x)
+
+        # Check if parameters are viable
+        if self.physical_viability:
+            self.check_optimal_parameters(x)
+
         # Return best position and score
         return x, f if self._minimising else -f
 
@@ -464,3 +474,16 @@ class Optimisation:
         """
         for i, param in enumerate(self.cost.problem.parameters):
             param.update(value=x[i])
+
+    def check_optimal_parameters(self, x):
+        """
+        Check if the optimised parameters are physically viable.
+        """
+
+        if self.cost.problem._model.check_params(inputs=x, silent=False):
+            return
+        else:
+            warnings.warn(
+                "Optimised parameters are not physically viable! Consider retrying optimisation",
+                UserWarning,
+            )

--- a/pybop/models/base_model.py
+++ b/pybop/models/base_model.py
@@ -28,7 +28,7 @@ class BaseModel:
         self.dataset = None
         self.signal = None
         self.param_check_counter = 0
-        self.infeasible_locations = True
+        self.allow_infeasible_solutions = True
 
     def build(
         self,
@@ -165,7 +165,7 @@ class BaseModel:
             if not isinstance(inputs, dict):
                 inputs = {key: inputs[i] for i, key in enumerate(self.fit_keys)}
 
-            if self.check_params(inputs, self.infeasible_locations):
+            if self.check_params(inputs, self.allow_infeasible_solutions):
                 sol = self.solver.solve(self.built_model, inputs=inputs, t_eval=t_eval)
 
                 predictions = [sol[signal].data for signal in self.signal]
@@ -205,7 +205,7 @@ class BaseModel:
             if not isinstance(inputs, dict):
                 inputs = {key: inputs[i] for i, key in enumerate(self.fit_keys)}
 
-            if self.check_params(inputs, self.infeasible_locations):
+            if self.check_params(inputs, self.allow_infeasible_solutions):
                 sol = self.solver.solve(
                     self.built_model,
                     inputs=inputs,
@@ -279,7 +279,7 @@ class BaseModel:
                 inputs = {key: inputs[i] for i, key in enumerate(self.fit_keys)}
             parameter_set.update(inputs)
 
-        if self.check_params(inputs, self.infeasible_locations):
+        if self.check_params(inputs, self.allow_infeasible_solutions):
             if self._unprocessed_model is not None:
                 if experiment is None:
                     return pybamm.Simulation(
@@ -300,7 +300,7 @@ class BaseModel:
         else:
             return [np.inf]
 
-    def check_params(self, inputs=None, infeasible_locations=True):
+    def check_params(self, inputs=None, allow_infeasible_solutions=True):
         """
         Check compatibility of the model parameters.
 
@@ -308,7 +308,7 @@ class BaseModel:
         ----------
         inputs : dict
             The input parameters for the simulation.
-        infeasible_locations : bool, optional
+        allow_infeasible_solutions : bool, optional
             If True, infeasible parameter values will be allowed in the optimisation (default: True).
 
         Returns
@@ -322,10 +322,10 @@ class BaseModel:
                 inputs = {key: inputs[i] for i, key in enumerate(self.fit_keys)}
 
         return self._check_params(
-            inputs=inputs, infeasible_locations=infeasible_locations
+            inputs=inputs, allow_infeasible_solutions=allow_infeasible_solutions
         )
 
-    def _check_params(self, inputs=None, infeasible_locations=True):
+    def _check_params(self, inputs=None, allow_infeasible_solutions=True):
         """
         A compatibility check for the model parameters which can be implemented by subclasses
         if required, otherwise it returns True by default.
@@ -334,7 +334,7 @@ class BaseModel:
         ----------
         inputs : dict
             The input parameters for the simulation.
-        infeasible_locations : bool, optional
+        allow_infeasible_solutions : bool, optional
             If True, infeasible parameter values will be allowed in the optimisation (default: True).
 
         Returns

--- a/pybop/models/base_model.py
+++ b/pybop/models/base_model.py
@@ -302,13 +302,14 @@ class BaseModel:
 
     def check_params(self, inputs=None, infeasible_locations=True):
         """
-        A compatibility check for the model parameters which can be implemented by subclasses
-        if required, otherwise it returns True by default.
+        Check compatibility of the model parameters.
 
         Parameters
         ----------
         inputs : dict
             The input parameters for the simulation.
+        infeasible_locations : bool, optional
+            If True, infeasible parameter values will be allowed in the optimisation (default: True).
 
         Returns
         -------
@@ -323,6 +324,25 @@ class BaseModel:
         return self._check_params(
             inputs=inputs, infeasible_locations=infeasible_locations
         )
+
+    def _check_params(self, inputs=None, infeasible_locations=True):
+        """
+        A compatibility check for the model parameters which can be implemented by subclasses
+        if required, otherwise it returns True by default.
+
+        Parameters
+        ----------
+        inputs : dict
+            The input parameters for the simulation.
+        infeasible_locations : bool, optional
+            If True, infeasible parameter values will be allowed in the optimisation (default: True).
+
+        Returns
+        -------
+        bool
+            A boolean which signifies whether the parameters are compatible.
+        """
+        return True
 
     @property
     def built_model(self):

--- a/pybop/models/base_model.py
+++ b/pybop/models/base_model.py
@@ -28,6 +28,7 @@ class BaseModel:
         self.dataset = None
         self.signal = None
         self.param_check_counter = 0
+        self.infesible_locations = True
 
     def build(
         self,
@@ -164,7 +165,7 @@ class BaseModel:
             if not isinstance(inputs, dict):
                 inputs = {key: inputs[i] for i, key in enumerate(self.fit_keys)}
 
-            if self.check_params(inputs):
+            if self.check_params(inputs, self.infesible_locations):
                 sol = self.solver.solve(self.built_model, inputs=inputs, t_eval=t_eval)
 
                 predictions = [sol[signal].data for signal in self.signal]
@@ -204,7 +205,7 @@ class BaseModel:
             if not isinstance(inputs, dict):
                 inputs = {key: inputs[i] for i, key in enumerate(self.fit_keys)}
 
-            if self.check_params(inputs):
+            if self.check_params(inputs, self.infesible_locations):
                 sol = self.solver.solve(
                     self.built_model,
                     inputs=inputs,
@@ -278,7 +279,7 @@ class BaseModel:
                 inputs = {key: inputs[i] for i, key in enumerate(self.fit_keys)}
             parameter_set.update(inputs)
 
-        if self.check_params(inputs):
+        if self.check_params(inputs, self.infesible_locations):
             if self._unprocessed_model is not None:
                 if experiment is None:
                     return pybamm.Simulation(
@@ -299,7 +300,7 @@ class BaseModel:
         else:
             return [np.inf]
 
-    def check_params(self, inputs=None, silent=True):
+    def check_params(self, inputs=None, infesible_locations=True):
         """
         A compatibility check for the model parameters which can be implemented by subclasses
         if required, otherwise it returns True by default.
@@ -319,7 +320,9 @@ class BaseModel:
             if not isinstance(inputs, dict):
                 inputs = {key: inputs[i] for i, key in enumerate(self.fit_keys)}
 
-        return self._check_params(inputs=inputs, silent=silent)
+        return self._check_params(
+            inputs=inputs, infesible_locations=infesible_locations
+        )
 
     @property
     def built_model(self):

--- a/pybop/models/base_model.py
+++ b/pybop/models/base_model.py
@@ -27,6 +27,7 @@ class BaseModel:
         self.parameters = None
         self.dataset = None
         self.signal = None
+        self.param_check_counter = 0
 
     def build(
         self,
@@ -298,7 +299,7 @@ class BaseModel:
         else:
             return [np.inf]
 
-    def check_params(self, inputs=None):
+    def check_params(self, inputs=None, silent=True):
         """
         A compatibility check for the model parameters which can be implemented by subclasses
         if required, otherwise it returns True by default.
@@ -314,7 +315,11 @@ class BaseModel:
             A boolean which signifies whether the parameters are compatible.
 
         """
-        return True
+        if inputs is not None:
+            if not isinstance(inputs, dict):
+                inputs = {key: inputs[i] for i, key in enumerate(self.fit_keys)}
+
+        return self._check_params(inputs=inputs, silent=silent)
 
     @property
     def built_model(self):

--- a/pybop/models/base_model.py
+++ b/pybop/models/base_model.py
@@ -28,7 +28,7 @@ class BaseModel:
         self.dataset = None
         self.signal = None
         self.param_check_counter = 0
-        self.infesible_locations = True
+        self.infeasible_locations = True
 
     def build(
         self,
@@ -165,7 +165,7 @@ class BaseModel:
             if not isinstance(inputs, dict):
                 inputs = {key: inputs[i] for i, key in enumerate(self.fit_keys)}
 
-            if self.check_params(inputs, self.infesible_locations):
+            if self.check_params(inputs, self.infeasible_locations):
                 sol = self.solver.solve(self.built_model, inputs=inputs, t_eval=t_eval)
 
                 predictions = [sol[signal].data for signal in self.signal]
@@ -205,7 +205,7 @@ class BaseModel:
             if not isinstance(inputs, dict):
                 inputs = {key: inputs[i] for i, key in enumerate(self.fit_keys)}
 
-            if self.check_params(inputs, self.infesible_locations):
+            if self.check_params(inputs, self.infeasible_locations):
                 sol = self.solver.solve(
                     self.built_model,
                     inputs=inputs,
@@ -279,7 +279,7 @@ class BaseModel:
                 inputs = {key: inputs[i] for i, key in enumerate(self.fit_keys)}
             parameter_set.update(inputs)
 
-        if self.check_params(inputs, self.infesible_locations):
+        if self.check_params(inputs, self.infeasible_locations):
             if self._unprocessed_model is not None:
                 if experiment is None:
                     return pybamm.Simulation(
@@ -300,7 +300,7 @@ class BaseModel:
         else:
             return [np.inf]
 
-    def check_params(self, inputs=None, infesible_locations=True):
+    def check_params(self, inputs=None, infeasible_locations=True):
         """
         A compatibility check for the model parameters which can be implemented by subclasses
         if required, otherwise it returns True by default.
@@ -321,7 +321,7 @@ class BaseModel:
                 inputs = {key: inputs[i] for i, key in enumerate(self.fit_keys)}
 
         return self._check_params(
-            inputs=inputs, infesible_locations=infesible_locations
+            inputs=inputs, infeasible_locations=infeasible_locations
         )
 
     @property

--- a/pybop/models/empirical/ecm.py
+++ b/pybop/models/empirical/ecm.py
@@ -76,7 +76,7 @@ class Thevenin(BaseModel):
         self._mesh = None
         self._disc = None
 
-    def _check_params(self, inputs=None, infesible_locations=True):
+    def _check_params(self, inputs=None, infeasible_locations=True):
         """
         A compatibility check for the model parameters which can be implemented by subclasses
         if required, otherwise it returns True by default.

--- a/pybop/models/empirical/ecm.py
+++ b/pybop/models/empirical/ecm.py
@@ -75,3 +75,21 @@ class Thevenin(BaseModel):
         self._built_initial_soc = None
         self._mesh = None
         self._disc = None
+
+    def _check_params(self, inputs=None, silent=True):
+        """
+        A compatibility check for the model parameters which can be implemented by subclasses
+        if required, otherwise it returns True by default.
+
+        Parameters
+        ----------
+        inputs : dict
+            The input parameters for the simulation.
+
+        Returns
+        -------
+        bool
+            A boolean which signifies whether the parameters are compatible.
+
+        """
+        return True

--- a/pybop/models/empirical/ecm.py
+++ b/pybop/models/empirical/ecm.py
@@ -76,7 +76,7 @@ class Thevenin(BaseModel):
         self._mesh = None
         self._disc = None
 
-    def _check_params(self, inputs=None, silent=True):
+    def _check_params(self, inputs=None, infesible_locations=True):
         """
         A compatibility check for the model parameters which can be implemented by subclasses
         if required, otherwise it returns True by default.

--- a/pybop/models/empirical/ecm.py
+++ b/pybop/models/empirical/ecm.py
@@ -76,7 +76,7 @@ class Thevenin(BaseModel):
         self._mesh = None
         self._disc = None
 
-    def _check_params(self, inputs=None, infeasible_locations=True):
+    def _check_params(self, inputs=None, allow_infeasible_solutions=True):
         """
         Check the compatibility of the model parameters.
 
@@ -84,7 +84,7 @@ class Thevenin(BaseModel):
         ----------
         inputs : dict
             The input parameters for the simulation.
-        infeasible_locations : bool, optional
+        allow_infeasible_solutions : bool, optional
             If True, infeasible parameter values will be allowed in the optimisation (default: True).
 
         Returns

--- a/pybop/models/empirical/ecm.py
+++ b/pybop/models/empirical/ecm.py
@@ -78,13 +78,14 @@ class Thevenin(BaseModel):
 
     def _check_params(self, inputs=None, infeasible_locations=True):
         """
-        A compatibility check for the model parameters which can be implemented by subclasses
-        if required, otherwise it returns True by default.
+        Check the compatibility of the model parameters.
 
         Parameters
         ----------
         inputs : dict
             The input parameters for the simulation.
+        infeasible_locations : bool, optional
+            If True, infeasible parameter values will be allowed in the optimisation (default: True).
 
         Returns
         -------

--- a/pybop/models/lithium_ion/echem.py
+++ b/pybop/models/lithium_ion/echem.py
@@ -71,7 +71,7 @@ class SPM(BaseModel):
 
         self._electrode_soh = pybamm.lithium_ion.electrode_soh
 
-    def _check_params(self, inputs=None, infeasible_locations=True):
+    def _check_params(self, inputs=None, allow_infeasible_solutions=True):
         """
         Check compatibility of the model parameters.
 
@@ -79,7 +79,7 @@ class SPM(BaseModel):
         ----------
         inputs : dict
             The input parameters for the simulation.
-        infeasible_locations : bool, optional
+        allow_infeasible_solutions : bool, optional
             If True, infeasible parameter values will be allowed in the optimisation (default: True).
 
         Returns
@@ -116,7 +116,7 @@ class SPM(BaseModel):
                     infeasibility_warning = "Non-physical point encountered - [{material_vol_fraction} + {porosity}] > 1.0!"
                     warnings.warn(infeasibility_warning, UserWarning)
                 self.param_check_counter += 1
-                return infeasible_locations
+                return allow_infeasible_solutions
 
         return True
 
@@ -191,7 +191,7 @@ class SPMe(BaseModel):
 
         self._electrode_soh = pybamm.lithium_ion.electrode_soh
 
-    def _check_params(self, inputs=None, infeasible_locations=True):
+    def _check_params(self, inputs=None, allow_infeasible_solutions=True):
         """
         Check compatibility of the model parameters.
 
@@ -199,7 +199,7 @@ class SPMe(BaseModel):
         ----------
         inputs : dict
             The input parameters for the simulation.
-        infeasible_locations : bool, optional
+        allow_infeasible_solutions : bool, optional
             If True, infeasible parameter values will be allowed in the optimisation (default: True).
 
         Returns
@@ -236,6 +236,6 @@ class SPMe(BaseModel):
                     infeasibility_warning = "Non-physical point encountered - [{material_vol_fraction} + {porosity}] > 1.0!"
                     warnings.warn(infeasibility_warning, UserWarning)
                 self.param_check_counter += 1
-                return infeasible_locations
+                return allow_infeasible_solutions
 
         return True

--- a/pybop/models/lithium_ion/echem.py
+++ b/pybop/models/lithium_ion/echem.py
@@ -71,7 +71,7 @@ class SPM(BaseModel):
 
         self._electrode_soh = pybamm.lithium_ion.electrode_soh
 
-    def check_params(self, inputs=None):
+    def _check_params(self, inputs=None, silent=True):
         """
         A compatibility check for the model parameters which can be implemented by subclasses
         if required, otherwise it returns True by default.
@@ -85,45 +85,41 @@ class SPM(BaseModel):
         -------
         bool
             A boolean which signifies whether the parameters are compatible.
-
         """
-        related_parameters = dict.fromkeys(
-            [
+
+        electrode_params = [
+            (
                 "Negative electrode active material volume fraction",
                 "Negative electrode porosity",
+            ),
+            (
                 "Positive electrode active material volume fraction",
                 "Positive electrode porosity",
-            ]
-        )
+            ),
+        ]
 
-        for key in related_parameters.keys():
-            if inputs is not None and key in inputs.keys():
-                related_parameters[key] = inputs[key]
-            else:
-                related_parameters[key] = self._parameter_set[key]
+        related_parameters = {
+            key: inputs.get(key)
+            if inputs and key in inputs
+            else self._parameter_set[key]
+            for pair in electrode_params
+            for key in pair
+        }
 
-        if (
-            related_parameters["Negative electrode active material volume fraction"]
-            + related_parameters["Negative electrode porosity"]
-        ) > 1:
-            warnings.warn(
-                "Non-physical point encountered - [Negative electrode active material volume fraction + Negative electrode porosity] > 1.0!",
-                UserWarning,
-            )
-            return True
+        def warn_and_return(warn_message):
+            warnings.warn(warn_message, UserWarning)
+            return silent
 
-        elif (
-            related_parameters["Positive electrode active material volume fraction"]
-            + related_parameters["Positive electrode porosity"]
-        ) > 1:
-            warnings.warn(
-                "Non-physical point encountered - [Positive electrode active material volume fraction + Positive electrode porosity] > 1.0!",
-                UserWarning,
-            )
-            return True
+        for material_vol_fraction, porosity in electrode_params:
+            if related_parameters[material_vol_fraction] + related_parameters[
+                porosity
+            ] > 1 and self.param_check_counter <= len(electrode_params):
+                self.param_check_counter += 1
+                return warn_and_return(
+                    f"Non-physical point encountered - [{material_vol_fraction} + {porosity}] > 1.0!"
+                )
 
-        else:
-            return True
+        return True
 
 
 class SPMe(BaseModel):
@@ -196,7 +192,7 @@ class SPMe(BaseModel):
 
         self._electrode_soh = pybamm.lithium_ion.electrode_soh
 
-    def check_params(self, inputs=None):
+    def _check_params(self, inputs=None, silent=True):
         """
         A compatibility check for the model parameters which can be implemented by subclasses
         if required, otherwise it returns True by default.
@@ -210,42 +206,38 @@ class SPMe(BaseModel):
         -------
         bool
             A boolean which signifies whether the parameters are compatible.
-
         """
-        related_parameters = dict.fromkeys(
-            [
+
+        electrode_params = [
+            (
                 "Negative electrode active material volume fraction",
                 "Negative electrode porosity",
+            ),
+            (
                 "Positive electrode active material volume fraction",
                 "Positive electrode porosity",
-            ]
-        )
+            ),
+        ]
 
-        for key in related_parameters.keys():
-            if inputs is not None and key in inputs.keys():
-                related_parameters[key] = inputs[key]
-            else:
-                related_parameters[key] = self._parameter_set[key]
+        related_parameters = {
+            key: inputs.get(key)
+            if inputs and key in inputs
+            else self._parameter_set[key]
+            for pair in electrode_params
+            for key in pair
+        }
 
-        if (
-            related_parameters["Negative electrode active material volume fraction"]
-            + related_parameters["Negative electrode porosity"]
-        ) > 1:
-            warnings.warn(
-                "Non-physical point encountered - [Negative electrode active material volume fraction + Negative electrode porosity] > 1.0!",
-                UserWarning,
-            )
-            return True
+        def warn_and_return(warn_message):
+            warnings.warn(warn_message, UserWarning)
+            return silent
 
-        elif (
-            related_parameters["Positive electrode active material volume fraction"]
-            + related_parameters["Positive electrode porosity"]
-        ) > 1:
-            warnings.warn(
-                "Non-physical point encountered - [Positive electrode active material volume fraction + Positive electrode porosity] > 1.0!",
-                UserWarning,
-            )
-            return True
+        for material_vol_fraction, porosity in electrode_params:
+            if related_parameters[material_vol_fraction] + related_parameters[
+                porosity
+            ] > 1 and self.param_check_counter <= len(electrode_params):
+                self.param_check_counter += 1
+                return warn_and_return(
+                    f"Non-physical point encountered - [{material_vol_fraction} + {porosity}] > 1.0!"
+                )
 
-        else:
-            return True
+        return True

--- a/pybop/models/lithium_ion/echem.py
+++ b/pybop/models/lithium_ion/echem.py
@@ -71,7 +71,7 @@ class SPM(BaseModel):
 
         self._electrode_soh = pybamm.lithium_ion.electrode_soh
 
-    def _check_params(self, inputs=None, silent=True):
+    def _check_params(self, inputs=None, infesible_locations=True):
         """
         A compatibility check for the model parameters which can be implemented by subclasses
         if required, otherwise it returns True by default.
@@ -108,7 +108,7 @@ class SPM(BaseModel):
 
         def warn_and_return(warn_message):
             warnings.warn(warn_message, UserWarning)
-            return silent
+            return infesible_locations
 
         for material_vol_fraction, porosity in electrode_params:
             if related_parameters[material_vol_fraction] + related_parameters[
@@ -192,7 +192,7 @@ class SPMe(BaseModel):
 
         self._electrode_soh = pybamm.lithium_ion.electrode_soh
 
-    def _check_params(self, inputs=None, silent=True):
+    def _check_params(self, inputs=None, infesible_locations=True):
         """
         A compatibility check for the model parameters which can be implemented by subclasses
         if required, otherwise it returns True by default.
@@ -229,7 +229,7 @@ class SPMe(BaseModel):
 
         def warn_and_return(warn_message):
             warnings.warn(warn_message, UserWarning)
-            return silent
+            return infesible_locations
 
         for material_vol_fraction, porosity in electrode_params:
             if related_parameters[material_vol_fraction] + related_parameters[

--- a/pybop/models/lithium_ion/echem.py
+++ b/pybop/models/lithium_ion/echem.py
@@ -1,4 +1,5 @@
 import pybamm
+import warnings
 from ..base_model import BaseModel
 
 
@@ -105,13 +106,21 @@ class SPM(BaseModel):
             related_parameters["Negative electrode active material volume fraction"]
             + related_parameters["Negative electrode porosity"]
         ) > 1:
-            return False
+            warnings.warn(
+                "Non-physical point encountered - [Negative electrode active material volume fraction + Negative electrode porosity] > 1.0!",
+                UserWarning,
+            )
+            return True
 
         elif (
             related_parameters["Positive electrode active material volume fraction"]
             + related_parameters["Positive electrode porosity"]
         ) > 1:
-            return False
+            warnings.warn(
+                "Non-physical point encountered - [Positive electrode active material volume fraction + Positive electrode porosity] > 1.0!",
+                UserWarning,
+            )
+            return True
 
         else:
             return True
@@ -222,13 +231,21 @@ class SPMe(BaseModel):
             related_parameters["Negative electrode active material volume fraction"]
             + related_parameters["Negative electrode porosity"]
         ) > 1:
-            return False
+            warnings.warn(
+                "Non-physical point encountered - [Negative electrode active material volume fraction + Negative electrode porosity] > 1.0!",
+                UserWarning,
+            )
+            return True
 
         elif (
             related_parameters["Positive electrode active material volume fraction"]
             + related_parameters["Positive electrode porosity"]
         ) > 1:
-            return False
+            warnings.warn(
+                "Non-physical point encountered - [Positive electrode active material volume fraction + Positive electrode porosity] > 1.0!",
+                UserWarning,
+            )
+            return True
 
         else:
             return True

--- a/pybop/models/lithium_ion/echem.py
+++ b/pybop/models/lithium_ion/echem.py
@@ -80,6 +80,8 @@ class SPM(BaseModel):
         ----------
         inputs : dict
             The input parameters for the simulation.
+        infeasible_locations : bool, optional
+            If True, infeasible parameter values will be allowed in the optimisation (default: True).
 
         Returns
         -------
@@ -106,18 +108,16 @@ class SPM(BaseModel):
             for key in pair
         }
 
-        def warn_and_return(warn_message):
-            warnings.warn(warn_message, UserWarning)
-            return infeasible_locations
-
         for material_vol_fraction, porosity in electrode_params:
-            if related_parameters[material_vol_fraction] + related_parameters[
-                porosity
-            ] > 1 and self.param_check_counter <= len(electrode_params):
+            if (
+                related_parameters[material_vol_fraction] + related_parameters[porosity]
+                > 1
+            ):
+                if self.param_check_counter <= len(electrode_params):
+                    infeasibility_warning = "Non-physical point encountered - [{material_vol_fraction} + {porosity}] > 1.0!"
+                    warnings.warn(infeasibility_warning, UserWarning)
                 self.param_check_counter += 1
-                return warn_and_return(
-                    f"Non-physical point encountered - [{material_vol_fraction} + {porosity}] > 1.0!"
-                )
+                return infeasible_locations
 
         return True
 
@@ -201,6 +201,8 @@ class SPMe(BaseModel):
         ----------
         inputs : dict
             The input parameters for the simulation.
+        infeasible_locations : bool, optional
+            If True, infeasible parameter values will be allowed in the optimisation (default: True).
 
         Returns
         -------
@@ -227,17 +229,15 @@ class SPMe(BaseModel):
             for key in pair
         }
 
-        def warn_and_return(warn_message):
-            warnings.warn(warn_message, UserWarning)
-            return infeasible_locations
-
         for material_vol_fraction, porosity in electrode_params:
-            if related_parameters[material_vol_fraction] + related_parameters[
-                porosity
-            ] > 1 and self.param_check_counter <= len(electrode_params):
+            if (
+                related_parameters[material_vol_fraction] + related_parameters[porosity]
+                > 1
+            ):
+                if self.param_check_counter <= len(electrode_params):
+                    infeasibility_warning = "Non-physical point encountered - [{material_vol_fraction} + {porosity}] > 1.0!"
+                    warnings.warn(infeasibility_warning, UserWarning)
                 self.param_check_counter += 1
-                return warn_and_return(
-                    f"Non-physical point encountered - [{material_vol_fraction} + {porosity}] > 1.0!"
-                )
+                return infeasible_locations
 
         return True

--- a/pybop/models/lithium_ion/echem.py
+++ b/pybop/models/lithium_ion/echem.py
@@ -73,8 +73,7 @@ class SPM(BaseModel):
 
     def _check_params(self, inputs=None, infeasible_locations=True):
         """
-        A compatibility check for the model parameters which can be implemented by subclasses
-        if required, otherwise it returns True by default.
+        Check compatibility of the model parameters.
 
         Parameters
         ----------
@@ -194,8 +193,7 @@ class SPMe(BaseModel):
 
     def _check_params(self, inputs=None, infeasible_locations=True):
         """
-        A compatibility check for the model parameters which can be implemented by subclasses
-        if required, otherwise it returns True by default.
+        Check compatibility of the model parameters.
 
         Parameters
         ----------

--- a/pybop/models/lithium_ion/echem.py
+++ b/pybop/models/lithium_ion/echem.py
@@ -71,7 +71,7 @@ class SPM(BaseModel):
 
         self._electrode_soh = pybamm.lithium_ion.electrode_soh
 
-    def _check_params(self, inputs=None, infesible_locations=True):
+    def _check_params(self, inputs=None, infeasible_locations=True):
         """
         A compatibility check for the model parameters which can be implemented by subclasses
         if required, otherwise it returns True by default.
@@ -108,7 +108,7 @@ class SPM(BaseModel):
 
         def warn_and_return(warn_message):
             warnings.warn(warn_message, UserWarning)
-            return infesible_locations
+            return infeasible_locations
 
         for material_vol_fraction, porosity in electrode_params:
             if related_parameters[material_vol_fraction] + related_parameters[
@@ -192,7 +192,7 @@ class SPMe(BaseModel):
 
         self._electrode_soh = pybamm.lithium_ion.electrode_soh
 
-    def _check_params(self, inputs=None, infesible_locations=True):
+    def _check_params(self, inputs=None, infeasible_locations=True):
         """
         A compatibility check for the model parameters which can be implemented by subclasses
         if required, otherwise it returns True by default.
@@ -229,7 +229,7 @@ class SPMe(BaseModel):
 
         def warn_and_return(warn_message):
             warnings.warn(warn_message, UserWarning)
-            return infesible_locations
+            return infeasible_locations
 
         for material_vol_fraction, porosity in electrode_params:
             if related_parameters[material_vol_fraction] + related_parameters[

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -66,8 +66,8 @@ class TestCosts:
         # Test option setting
         sums_cost.set_fail_gradient(1)
 
-        # Test infesible locations
-        rmse_cost.problem._model.infesible_locations = False
+        # Test infeasible locations
+        rmse_cost.problem._model.infeasible_locations = False
         assert rmse_cost([1.1]) == np.inf
 
         # Test UserWarnings

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -56,18 +56,24 @@ class TestCosts:
         # Test type of returned value
         assert type(rmse_cost([0.5])) == np.float64
         assert rmse_cost([0.5]) >= 0
-        assert rmse_cost([1.1]) == np.inf
 
         assert type(sums_cost([0.5])) == np.float64
         assert sums_cost([0.5]) >= 0
         e, de = sums_cost.evaluateS1([0.5])
         assert type(e) == np.float64
         assert type(de) == np.ndarray
-        e, de = sums_cost.evaluateS1([1.1])
-        assert e == np.inf
 
         # Test option setting
         sums_cost.set_fail_gradient(1)
+
+        # Test UserWarnings
+        with pytest.warns(UserWarning) as record:
+            rmse_cost([1.1])
+            sums_cost.evaluateS1([1.1])
+
+        assert len(record) == 2
+        for i in range(len(record)):
+            assert "Non-physical point encountered" in str(record[i].message)
 
         # Test exception for non-numeric inputs
         with pytest.raises(ValueError):

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -66,6 +66,10 @@ class TestCosts:
         # Test option setting
         sums_cost.set_fail_gradient(1)
 
+        # Test infesible locations
+        rmse_cost.problem._model.infesible_locations = False
+        assert rmse_cost([1.1]) == np.inf
+
         # Test UserWarnings
         with pytest.warns(UserWarning) as record:
             rmse_cost([1.1])

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -67,7 +67,7 @@ class TestCosts:
         sums_cost.set_fail_gradient(1)
 
         # Test infeasible locations
-        rmse_cost.problem._model.infeasible_locations = False
+        rmse_cost.problem._model.allow_infeasible_solutions = False
         assert rmse_cost([1.1]) == np.inf
 
         # Test UserWarnings

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -51,10 +51,10 @@ class TestModels:
         assert len(res["Terminal voltage [V]"].data) == 100
 
     @pytest.mark.unit
-    def test_predict_without_infeasible_locations(self):
+    def test_predict_without_allow_infeasible_solutions(self):
         # Define SPM
         model = pybop.lithium_ion.SPM()
-        model.infeasible_locations = False
+        model.allow_infeasible_solutions = False
         t_eval = np.linspace(0, 10, 100)
         inputs = {
             "Negative electrode active material volume fraction": 0.9,

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -51,6 +51,20 @@ class TestModels:
         assert len(res["Terminal voltage [V]"].data) == 100
 
     @pytest.mark.unit
+    def test_predict_without_infeasible_locations(self):
+        # Define SPM
+        model = pybop.lithium_ion.SPM()
+        model.infeasible_locations = False
+        t_eval = np.linspace(0, 10, 100)
+        inputs = {
+            "Negative electrode active material volume fraction": 0.9,
+            "Positive electrode active material volume fraction": 0.9,
+        }
+
+        res = model.predict(t_eval=t_eval, inputs=inputs)
+        assert np.isinf(res).any()
+
+    @pytest.mark.unit
     def test_build(self):
         model = pybop.lithium_ion.SPM()
         model.build()

--- a/tests/unit/test_parameterisations.py
+++ b/tests/unit/test_parameterisations.py
@@ -131,6 +131,11 @@ class TestModelParameterisation:
             parameterisation.set_max_iterations(125)
             x, final_cost = parameterisation.run()
 
+        elif optimiser in [pybop.SciPyMinimize]:
+            parameterisation.cost.problem._model.infeasible_locations = False
+            parameterisation.set_max_iterations(125)
+            x, final_cost = parameterisation.run()
+
         else:
             parameterisation.set_max_iterations(125)
             x, final_cost = parameterisation.run()

--- a/tests/unit/test_parameterisations.py
+++ b/tests/unit/test_parameterisations.py
@@ -104,7 +104,7 @@ class TestModelParameterisation:
     def test_spm_optimisers(self, optimiser, spm_cost, x0):
         # Test each optimiser
         parameterisation = pybop.Optimisation(cost=spm_cost, optimiser=optimiser)
-        parameterisation.set_max_unchanged_iterations(iterations=15, threshold=5e-4)
+        parameterisation.set_max_unchanged_iterations(iterations=25, threshold=5e-4)
 
         if optimiser in [pybop.CMAES]:
             parameterisation.set_f_guessed_tracking(True)
@@ -113,14 +113,14 @@ class TestModelParameterisation:
             x, final_cost = parameterisation.run()
 
             parameterisation.set_f_guessed_tracking(False)
-            parameterisation.set_max_iterations(100)
+            parameterisation.set_max_iterations(125)
 
             x, final_cost = parameterisation.run()
-            assert parameterisation._max_iterations == 100
+            assert parameterisation._max_iterations == 125
 
         elif optimiser in [pybop.GradientDescent]:
-            parameterisation.optimiser.set_learning_rate(0.025)
-            parameterisation.set_max_iterations(100)
+            parameterisation.optimiser.set_learning_rate(0.02)
+            parameterisation.set_max_iterations(150)
             x, final_cost = parameterisation.run()
 
         elif optimiser in [pybop.SciPyDifferentialEvolution]:
@@ -128,11 +128,11 @@ class TestModelParameterisation:
                 parameterisation.optimiser.set_population_size(-5)
 
             parameterisation.optimiser.set_population_size(5)
-            parameterisation.set_max_iterations(100)
+            parameterisation.set_max_iterations(125)
             x, final_cost = parameterisation.run()
 
         else:
-            parameterisation.set_max_iterations(100)
+            parameterisation.set_max_iterations(125)
             x, final_cost = parameterisation.run()
 
         # Assertions

--- a/tests/unit/test_parameterisations.py
+++ b/tests/unit/test_parameterisations.py
@@ -132,7 +132,7 @@ class TestModelParameterisation:
             x, final_cost = parameterisation.run()
 
         elif optimiser in [pybop.SciPyMinimize]:
-            parameterisation.cost.problem._model.infeasible_locations = False
+            parameterisation.cost.problem._model.allow_infeasible_solutions = False
             parameterisation.set_max_iterations(125)
             x, final_cost = parameterisation.run()
 


### PR DESCRIPTION
When returning `np.inf` for non-physical optimisation iterations, the gradient-based optimisers struggle to converge due to the lack of stable gradient information (either with a fixed value or trying to create a fake gradient). Currently, for the active material fitting examples & tests, the `np.inf` occurs infinitesimally past the cost minimum. This is a difficult challenge to solve robustly for different optimisation cases, so instead of trying to integrate the fake gradient/cost into the landscape, I suggest we leave the default functionality to not return `np.inf` and replace it with a `UserWarning`.

To do this I've add the argument `allow_infeasible_solutions` to `model.check_params()` that modifies that silences the method return (i.e return `True`). I've also added a `UserWarning` with a counter to limit the warning displayed during optimisation. This allows the cost and gradient surfaces to remain continuous and has largely resolved the test suite failures, but still retains the original functionality if silent passed as `True`

In addition, the gradient-based optimisers are quite sensitive to initial conditions, so I initialised them at a lower gradient location to help with convergence. This is probably something we should think about and update in the longer term. At the very least we should keep it in mind when recommending optimisers. This PR also increases the `max_iterations` to help reduce the number of sporadic convergence failures we experience.

Closes #164.