### PR TITLE
Add fitting functionality for geometric parameters

### DIFF
--- a/examples/scripts/spm_geometric_parameters.py
+++ b/examples/scripts/spm_geometric_parameters.py
@@ -1,0 +1,60 @@
+import pybop
+import numpy as np
+
+# Define model
+parameter_set = pybop.ParameterSet.pybamm("Chen2020")
+model = pybop.lithium_ion.SPM(parameter_set=parameter_set)
+
+# Fitting parameters
+parameters = [
+    pybop.Parameter(
+        "Positive particle radius [m]",
+        prior=pybop.Gaussian(5.22e-06, 0.05e-06),
+        bounds=[4e-06, 6e-06],
+    ),
+    pybop.Parameter(
+        "Positive electrode active material volume fraction",
+        prior=pybop.Gaussian(0.48, 0.05),
+        bounds=[0.4, 0.7],
+    ),
+]
+
+# Generate data
+sigma = 0.001
+t_eval = np.arange(0, 900, 2)
+values = model.predict(t_eval=t_eval)
+corrupt_values = values["Voltage [V]"].data + np.random.normal(0, sigma, len(t_eval))
+
+# Form dataset
+dataset = pybop.Dataset(
+    {
+        "Time [s]": t_eval,
+        "Current function [A]": values["Current [A]"].data,
+        "Voltage [V]": corrupt_values,
+    }
+)
+
+# Generate problem, cost function, and optimisation class
+problem = pybop.FittingProblem(model, parameters, dataset)
+cost = pybop.SumSquaredError(problem)
+optim = pybop.Optimisation(cost, optimiser=pybop.CMAES)
+optim.set_max_iterations(100)
+
+# Run the optimisation
+x, final_cost = optim.run()
+print("Estimated parameters:", x)
+
+# Plot the timeseries output
+pybop.quick_plot(x, cost, title="Optimised Comparison")
+
+# Plot convergence
+pybop.plot_convergence(optim)
+
+# Plot the parameter traces
+pybop.plot_parameters(optim)
+
+# Plot the cost landscape
+pybop.plot_cost2d(cost, steps=15)
+
+# Plot the cost landscape with optimisation path and updated bounds
+pybop.plot_cost2d(cost, optim=optim, steps=15)

--- a/examples/scripts/spm_geometric_parameters.py
+++ b/examples/scripts/spm_geometric_parameters.py
@@ -10,12 +10,12 @@ parameters = [
     pybop.Parameter(
         "Positive particle radius [m]",
         prior=pybop.Gaussian(5.22e-06, 0.05e-06),
-        bounds=[4e-06, 6e-06],
+        bounds=[5e-06, 6e-06],
     ),
     pybop.Parameter(
-        "Positive electrode active material volume fraction",
-        prior=pybop.Gaussian(0.48, 0.05),
-        bounds=[0.4, 0.7],
+        "Negative particle radius [m]",
+        prior=pybop.Gaussian(5.9e-06, 0.05e-06),
+        bounds=[5e-06, 6.5e-06],
     ),
 ]
 
@@ -37,7 +37,7 @@ dataset = pybop.Dataset(
 # Generate problem, cost function, and optimisation class
 problem = pybop.FittingProblem(model, parameters, dataset)
 cost = pybop.SumSquaredError(problem)
-optim = pybop.Optimisation(cost, optimiser=pybop.CMAES)
+optim = pybop.Optimisation(cost, optimiser=pybop.SNES)
 optim.set_max_iterations(100)
 
 # Run the optimisation

--- a/pybop/_costs.py
+++ b/pybop/_costs.py
@@ -169,7 +169,6 @@ class RootMeanSquaredError(BaseCost):
             The root mean square error.
 
         """
-
         prediction = self.problem.evaluate(x)
 
         if len(prediction) < len(self._target):

--- a/pybop/_problem.py
+++ b/pybop/_problem.py
@@ -146,6 +146,7 @@ class FittingProblem(BaseProblem):
     ):
         super().__init__(parameters, model, check_model, signal, init_soc, x0)
         self._dataset = dataset.data
+        self.x = self.x0
 
         # Check that the dataset contains time and current
         for name in ["Time [s]", "Current function [A]"] + self.signal:
@@ -182,6 +183,13 @@ class FittingProblem(BaseProblem):
                 check_model=self.check_model,
                 init_soc=self.init_soc,
             )
+        elif self._model.has_predict is True:
+            self._model.rebuild(
+                dataset=self._dataset,
+                parameters=self.parameters,
+                check_model=self.check_model,
+                init_soc=self.init_soc,
+            )
 
     def evaluate(self, x):
         """
@@ -192,6 +200,10 @@ class FittingProblem(BaseProblem):
         x : np.ndarray
             Parameter values to evaluate the model at.
         """
+
+        if (x != self.x).all() and self._model.matched_parameters:
+            self._model.rebuild(parameters=self.parameters)
+            self.x = x
 
         y = np.asarray(self._model.simulate(inputs=x, t_eval=self._time_data))
 

--- a/pybop/_problem.py
+++ b/pybop/_problem.py
@@ -202,6 +202,9 @@ class FittingProblem(BaseProblem):
         """
 
         if (x != self.x).all() and self._model.matched_parameters:
+            for i, param in enumerate(self.parameters):
+                param.update(value=x[i])
+
             self._model.rebuild(parameters=self.parameters)
             self.x = x
 

--- a/pybop/models/lithium_ion/echem.py
+++ b/pybop/models/lithium_ion/echem.py
@@ -69,6 +69,32 @@ class SPM(BaseModel):
         self._disc = None
 
         self._electrode_soh = pybamm.lithium_ion.electrode_soh
+        self.rebuild_parameters = self.set_rebuild_parameters()
+
+    def set_rebuild_parameters(self):
+        """
+        Sets the parameters that can be changed when rebuilding the model.
+
+        Returns
+        -------
+        dict
+            A dictionary of parameters that can be changed when rebuilding the model.
+
+        """
+        rebuild_parameters = dict.fromkeys(
+            [
+                "Negative particle radius [m]",
+                "Negative electrode porosity",
+                "Negative electrode thickness [m]",
+                "Positive particle radius [m]",
+                "Positive electrode porosity",
+                "Positive electrode thickness [m]",
+                "Separator porosity",
+                "Separator thickness [m]",
+            ]
+        )
+
+        return rebuild_parameters
 
     def check_params(self, inputs=None):
         """
@@ -186,6 +212,32 @@ class SPMe(BaseModel):
         self._disc = None
 
         self._electrode_soh = pybamm.lithium_ion.electrode_soh
+        self.rebuild_parameters = self.set_rebuild_parameters()
+
+    def set_rebuild_parameters(self):
+        """
+        Sets the parameters that can be changed when rebuilding the model.
+
+        Returns
+        -------
+        dict
+            A dictionary of parameters that can be changed when rebuilding the model.
+
+        """
+        rebuild_parameters = dict.fromkeys(
+            [
+                "Negative particle radius [m]",
+                "Negative electrode porosity",
+                "Negative electrode thickness [m]",
+                "Positive particle radius [m]",
+                "Positive electrode porosity",
+                "Positive electrode thickness [m]",
+                "Separator porosity",
+                "Separator thickness [m]",
+            ]
+        )
+
+        return rebuild_parameters
 
     def check_params(self, inputs=None):
         """

--- a/pybop/plotting/plot_cost2d.py
+++ b/pybop/plotting/plot_cost2d.py
@@ -46,7 +46,7 @@ def plot_cost2d(cost, bounds=None, optim=None, steps=10):
     # Populate cost matrix
     for i, xi in enumerate(x):
         for j, yj in enumerate(y):
-            costs[j, i] = cost([xi, yj])
+            costs[j, i] = cost(np.array([xi, yj]))
 
     # Create figure
     fig = create_figure(x, y, costs, bounds, cost.problem.parameters, optim)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -59,3 +59,61 @@ class TestModels:
         # Test that the model can be built again
         model.build()
         assert model.built_model is not None
+
+    @pytest.mark.unit
+    def test_rebuild(self):
+        model = pybop.lithium_ion.SPM()
+        model.build()
+        initial_built_model = model._built_model
+        assert model._built_model is not None
+
+        # Test that the model can be built again
+        model.rebuild()
+        rebuilt_model = model._built_model
+        assert rebuilt_model is not None
+
+        # Filter out special and private attributes
+        attributes_to_compare = [
+            "algebraic",
+            "bcs",
+            "boundary_conditions",
+            "mass_matrix",
+            "parameters",
+            "submodels",
+            "summary_variables",
+            "rhs",
+            "variables",
+            "y_slices",
+        ]
+
+        # Loop through the filtered attributes and compare them
+        for attribute in attributes_to_compare:
+            assert getattr(rebuilt_model, attribute) == getattr(
+                initial_built_model, attribute
+            )
+
+    @pytest.mark.unit
+    def test_rebuild_geometric_parameters(self):
+        parameter_set = pybop.ParameterSet.pybamm("Chen2020")
+        model = pybop.lithium_ion.SPM(parameter_set=parameter_set)
+        model.build()
+        initial_built_model = model.copy()
+        assert initial_built_model._built_model is not None
+
+        # Test that the model can be built again
+        parameter_set.update({"Negative electrode thickness [m]": 4.00e-05})
+        model.rebuild(parameter_set=parameter_set)
+        rebuilt_model = model
+        assert rebuilt_model._built_model is not None
+
+        with pytest.raises(AssertionError):
+            assert (
+                rebuilt_model._mesh["negative electrode"].nodes[1]
+                == initial_built_model._mesh["negative electrode"].nodes[1]
+            ), "Mesh nodes mismatch"
+
+        with pytest.raises(AssertionError):
+            assert (
+                rebuilt_model.geometry["negative electrode"]["x_n"]["max"]
+                == initial_built_model.geometry["negative electrode"]["x_n"]["max"]
+            ), "Geometry max mismatch"


### PR DESCRIPTION
This PR adds functionality to fit geometric parameters in pybop. This essentially requires a model rebuild every iteration, but a combined effort to minimise the number of objects that get rebuilt. It completes the following:

- [ ] Adds `rebuild()` method to `base_model`
- [ ] Adds functionality to classify and store parameters based on their type (requires rebuild or not) via `model.rebuild_parameters`
- [ ] Adds `set_rebuild_parameters()` to create the required dictionary of geometric parameters
- [ ] Adds a `copy()` method to `base_model`
- [ ] A type change to `plot_cost2D()`
- [ ] Adds tests needed for coverage

Closes #18 