### PR TITLE
Splits integration / examples / unit tests

### DIFF
--- a/.github/workflows/scheduled_tests.yaml
+++ b/.github/workflows/scheduled_tests.yaml
@@ -6,9 +6,10 @@ on:
     branches:
       - main
 
-  # runs every day at 09:00 UTC
+  # runs every day at 09:00 and 15:00 UTC
   schedule:
     - cron: '0 9 * * *'
+    - cron: '0 15 * * *'
 
 jobs:
   build:
@@ -30,7 +31,7 @@ jobs:
           python -m pip install --upgrade pip nox
       - name: Unit tests with nox
         run: |
-          python -m nox -s unit
+          python -m nox -s coverage
           python -m nox -s notebooks
 
   #M-series Mac Mini
@@ -58,7 +59,7 @@ jobs:
           eval "$(pyenv init -)"
           pyenv activate pybop-${{ matrix.python-version }}
           python -m pip install --upgrade pip wheel setuptools nox
-          python -m nox -s unit
+          python -m nox -s coverage
           python -m nox -s notebooks
 
       - name: Uninstall pyenv-virtualenv & python

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,10 +18,24 @@ def coverage(session):
     session.run(
         "pytest",
         "--unit",
-        "--examples",
+        "--integration",
         "--cov",
         "--cov-report=xml",
     )
+
+
+@nox.session
+def integration(session):
+    session.run_always("pip", "install", "-e", ".[all]")
+    session.install("pytest", "pytest-mock")
+    session.run("pytest", "--integration")
+
+
+@nox.session
+def examples(session):
+    session.run_always("pip", "install", "-e", ".[all]")
+    session.install("pytest", "pytest-mock")
+    session.run("pytest", "--examples")
 
 
 @nox.session

--- a/pybop/_optimisation.py
+++ b/pybop/_optimisation.py
@@ -449,7 +449,7 @@ class Optimisation:
                 raise ValueError("Maximum number of iterations cannot be negative.")
         self._max_iterations = iterations
 
-    def set_max_unchanged_iterations(self, iterations=25, threshold=1e-5):
+    def set_max_unchanged_iterations(self, iterations=5, threshold=1e-5):
         """
         Set the maximum number of iterations without significant change as a stopping criterion.
         Credit: PINTS

--- a/pybop/costs/fitting_costs.py
+++ b/pybop/costs/fitting_costs.py
@@ -45,6 +45,46 @@ class RootMeanSquaredError(BaseCost):
         else:
             return np.sqrt(np.mean((prediction - self._target) ** 2))
 
+    def _evaluateS1(self, x):
+        """
+        Compute the cost and its gradient with respect to the parameters.
+
+        Parameters
+        ----------
+        x : array-like
+            The parameters for which to compute the cost and gradient.
+
+        Returns
+        -------
+        tuple
+            A tuple containing the cost and the gradient. The cost is a float,
+            and the gradient is an array-like of the same length as `x`.
+
+        Raises
+        ------
+        ValueError
+            If an error occurs during the calculation of the cost or gradient.
+        """
+        y, dy = self.problem.evaluateS1(x)
+        if len(y) < len(self._target):
+            e = np.float64(np.inf)
+            de = self._de * np.ones(self.n_parameters)
+        else:
+            dy = dy.reshape(
+                (
+                    self.problem.n_time_data,
+                    self.n_outputs,
+                    self.n_parameters,
+                )
+            )
+            r = y - self._target
+            e = np.sqrt(np.mean((r) ** 2))
+            de = np.mean((r.T * dy.T), axis=2) / np.sqrt(
+                np.mean((r.T * dy.T) ** 2, axis=2)
+            )
+
+        return e, de.flatten()
+
 
 class SumSquaredError(BaseCost):
     """

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -9,6 +9,7 @@ class TestExamples:
     A class to test the example scripts.
     """
 
+    @staticmethod
     def list_of_examples():
         list = []
         path_to_example_scripts = os.path.join(

--- a/tests/integration/test_plotly_manager.py
+++ b/tests/integration/test_plotly_manager.py
@@ -52,7 +52,7 @@ def uninstall_plotly_if_installed():
     plotly.io.renderers.default = None
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_initialization_with_plotly_installed(plotly_installed):
     """Test initialization when Plotly is installed."""
     assert is_package_installed("plotly")
@@ -67,7 +67,7 @@ def test_initialization_with_plotly_installed(plotly_installed):
     assert plotly_manager.make_subplots == make_subplots
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_prompt_for_plotly_installation(mocker, uninstall_plotly_if_installed):
     """Test prompt for Plotly installation when not installed."""
     assert not is_package_installed("plotly")
@@ -83,7 +83,7 @@ def test_prompt_for_plotly_installation(mocker, uninstall_plotly_if_installed):
     assert plotly_manager.make_subplots == make_subplots
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_cancel_installation(mocker, uninstall_plotly_if_installed):
     """Test exit if Plotly installation is canceled."""
     assert not is_package_installed("plotly")
@@ -96,7 +96,7 @@ def test_cancel_installation(mocker, uninstall_plotly_if_installed):
     assert not is_package_installed("plotly")
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_post_install_setup(plotly_installed):
     """Test post-install setup."""
     plotly_manager = PlotlyManager()

--- a/tests/unit/test_optimisation.py
+++ b/tests/unit/test_optimisation.py
@@ -104,9 +104,9 @@ class TestOptimisation:
     def test_halting(self, cost):
         # Test max evalutions
         optim = pybop.Optimisation(cost=cost, optimiser=pybop.GradientDescent)
-        optim.set_max_evaluations(10)
+        optim.set_max_evaluations(1)
         x, __ = optim.run()
-        assert optim._iterations == 10
+        assert optim._iterations == 1
 
         # Test max unchanged iterations
         optim = pybop.Optimisation(cost=cost, optimiser=pybop.GradientDescent)


### PR DESCRIPTION
This PR adds the following to close #139,

- Split integration and unit tests
- update pytest --examples
- additional scheduled workflow trigger
- add test_parameterisation cost/optimiser test matrix
- tightens the performance assertions for integration tests

It also,
- updates default `max_unchanged_iterations` from 25 to 5. This value was selected as a trade-off between robustness and performance, open to other defaults however.
- adds `_evaulateS1` to the `RootMeanSquared` cost function

