### PR TITLE
Update release workflow

### DIFF
--- a/.github/release_workflow.md
+++ b/.github/release_workflow.md
@@ -1,0 +1,34 @@
+# Release Workflow
+
+This document outlines the release workflow for publishing to PyPI and TestPyPI using GitHub Actions.
+
+## Creating a New Release
+
+To create a new release, follow these steps:
+
+1. **Prepare the Release:**
+   - Create a new branch for the release (i.e. `v24.XX`) from `develop`.
+   - Increment the following:
+         - The version number in the `pyproject.toml` file following CalVer versioning.
+         - The`CHANGELOG.md` version with the changes for the new version.
+   - Open a PR to the `main` branch. Once the PR is merged, proceed to the next step.
+
+2. **Tag the Release:**
+   - Create a new Git tag for the release. For a full release, use a tag like `v24.2`. For a release candidate, use a tag like `v24.2-rc.1`.
+   - Push the tag to the remote repository: `git push origin <tag_name>`.
+
+3. **Create a GitHub Release:**
+   - Go to the "Releases" section of on GitHub.
+   - Click "Draft a new release."
+   - Enter the tag you created in the "Tag version" field.
+   - Fill in the release title and description. Add any major changes and link to the `CHANGELOG.md` for a list of total changes.
+   - If it's a pre-release (release candidate), check the "This is a pre-release" checkbox.
+   - Click "Publish release" to create the release.
+
+4. **Monitor the Workflow:**
+   - Go to the "Actions" tab of your repository to monitor the workflow's progress.
+   - The workflow will build the distribution packages and then publish them to PyPI or TestPyPI, depending on whether the release is a full release or a pre-release.
+
+5. **Verify the Release:**
+   - Check PyPI or TestPyPI to ensure that your package is available and has been updated to the new version.
+   - Test installing the package using `pip` to ensure everything works as expected.

--- a/.github/workflows/release_action.yaml
+++ b/.github/workflows/release_action.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.8"
+        python-version: "3.12"
     - name: Install pypa/build
       run: >-
         python3 -m
@@ -23,7 +23,7 @@ jobs:
         build
         --user
     - name: Build a binary wheel and a source tarball
-      run: python3 -m build
+      run: python -m build
     - name: Store the distribution packages
       uses: actions/upload-artifact@v3
       with:
@@ -36,8 +36,7 @@ jobs:
     if: >
       startsWith(github.ref, 'refs/tags/') &&
       !contains(github.ref, 'rc')
-    needs:
-    - build
+    needs: build
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -53,6 +52,9 @@ jobs:
         path: dist/
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
 
   github-release:
     name: >-
@@ -113,3 +115,5 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
This adds:

- A [release_workflow.md](https://github.com/pybop-team/PyBOP/blob/06ac3743c3a95fd3476920beb35a73499316aace/.github/release_workflow.md) to clarify the release steps and workflow
- Updates the release_action.yaml for trusted publishing.