### PR TITLE
Pin `Pytest < 8.1.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
     "nox",
     "nbmake",
     "pre-commit",
-    "pytest>=6",
+    "pytest>=6, <8.1.0",
     "pytest-cov",
     "pytest-mock",
     "pytest-xdist",


### PR DESCRIPTION
Short-term pin of pytest version until breaking changes are solved in plugins.

Closes #225. 