### PR TITLE
Switch to `softprops/action-gh-release` to upload artifacts for GitHub Releases

### DIFF
--- a/.github/workflows/release_action.yaml
+++ b/.github/workflows/release_action.yaml
@@ -16,14 +16,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.12"
-    - name: Install pypa/build
-      run: >-
-        python3 -m
-        pip install
-        build
-        --user
-    - name: Build a binary wheel and a source tarball
-      run: python -m build
+    - name: Build a source tarball and a wheel from it
+      run: pipx run build
     - name: Store the distribution packages
       uses: actions/upload-artifact@v3
       with:
@@ -77,20 +71,17 @@ jobs:
         inputs: >-
           ./dist/*.tar.gz
           ./dist/*.whl
-    - name: Upload artifact signatures to GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      # Upload to GitHub Release using the `gh` CLI.
-      # `dist/` contains the built packages, and the
-      # sigstore-produced signatures and certificates.
-      run: >-
-        gh release upload
-        '${{ github.ref_name }}' dist/**
-        --repo '${{ github.repository }}'
+    - name: Publish artifacts and signatures to GitHub Releases
+      uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564  # v2.0.4
+      with:
+        # `dist/` contains the built packages, and the
+        # sigstore-produced signatures and certificates.
+        files: dist/*
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
-    if: contains(github.ref, 'rc') && github.repository == github.event.repository  # only publish to TestPyPI for rc tags
+    # only publish to TestPyPI for rc tags
+    if: contains(github.ref, 'rc') && github.repository == 'pybop-team/PyBOP'
     needs:
     - build
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- [#268](https://github.com/pybop-team/PyBOP/pull/268) - Fixes the GitHub Release artifact uploads, allowing verification of
+codesigned binaries and source distributions via `sigstore-python`.
 - [#267](https://github.com/pybop-team/PyBOP/pull/267) - Add classifiers to pyproject.toml, update project.urls.
 - [#195](https://github.com/pybop-team/PyBOP/issues/195) - Adds the Nelder-Mead optimiser from PINTS as another option.
 


### PR DESCRIPTION
# Description

This PR updates the `publish-to-pypi` job to upload the `sigstore`-generated signatures to the accompanying GitHub Release. These files were absent in the v24.3 release, which renders verifying the PyBOP wheel and the source distribution a tad difficult. Some other changes have been included as a part of small cleanups.

## Review
Before you mark your PR as ready for review, please ensure that you've considered the following:
- Updated the [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) in reverse chronological order (newest at the top) with a concise description of the changes, including the PR number.
- Noted any breaking changes, including details on how it might impact existing functionality.

## Type of change
- [ ] New Feature: A non-breaking change that adds new functionality.
- [ ] Optimization: A code change that improves performance.
- [ ] Bug Fix: A non-breaking change that addresses an issue.
- [ ] Documentation: Updates to documentation or new documentation for new features.
- [ ] Refactoring: Non-functional changes that improve the codebase.
- [x] Style: Non-functional changes related to code style (formatting, naming, etc).
- [ ] Testing: Additional tests to improve coverage or confirm functionality.
- [x] Other: Maintenance

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All unit tests pass: `$ nox -s tests`
- [x] The documentation builds: `$ nox -s docs`

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:
- [x] Code is well-commented, especially in complex or unclear areas.
- [ ] Added tests that prove my fix is effective or that my feature works.
- [ ] Checked that coverage remains or improves, and added tests if necessary to maintain or increase coverage.

Thank you for contributing to our project! Your efforts help us to deliver great software.
