### PR TITLE
Install seed packages (`setuptools` and `wheel`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ codesigned binaries and source distributions via `sigstore-python`.
 
 ## Bug Fixes
 
+- [#317](https://github.com/pybop-team/PyBOP/pull/317) - Installs seed packages into `nox` sessions, ensuring that scheduled tests can pass.
 - [#308](https://github.com/pybop-team/PyBOP/pull/308) - Enables testing on both macOS Intel and macOS ARM (Silicon) runners and fixes the scheduled tests.
 - [#299](https://github.com/pybop-team/PyBOP/pull/299) - Bugfix multiprocessing support for Linux, MacOS, Windows (WSL) and improves coverage.
 - [#270](https://github.com/pybop-team/PyBOP/pull/270) - Updates PR template.

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,6 +14,7 @@ PYBAMM_VERSION = os.environ.get("PYBAMM_VERSION", None)
 
 @nox.session
 def unit(session):
+    session.install("setuptools", "wheel")
     session.install("-e", ".[all,dev]", silent=False)
     if PYBOP_SCHEDULED:
         session.run("pip", "install", f"pybamm=={PYBAMM_VERSION}", silent=False)
@@ -22,6 +23,7 @@ def unit(session):
 
 @nox.session
 def coverage(session):
+    session.install("setuptools", "wheel")
     session.install("-e", ".[all,dev]", silent=False)
     session.install("pip")
     if PYBOP_SCHEDULED:
@@ -41,6 +43,8 @@ def coverage(session):
 
 @nox.session
 def plots(session):
+    """Run the tests that generate plots."""
+    session.install("setuptools", "wheel")
     session.install("-e", ".[plot,dev]", silent=False)
     session.install("pip")
     session.run("pytest", "--plots", "-n", "0")
@@ -48,6 +52,8 @@ def plots(session):
 
 @nox.session
 def integration(session):
+    """Run the integration tests."""
+    session.install("setuptools", "wheel")
     session.install("-e", ".[all,dev]", silent=False)
     session.run("pytest", "--integration")
 
@@ -55,6 +61,7 @@ def integration(session):
 @nox.session
 def examples(session):
     """Run the examples and notebooks"""
+    session.install("setuptools", "wheel")
     session.install("-e", ".[all,dev]", silent=False)
     session.run("pytest", "--examples")
     notebooks(session)
@@ -63,6 +70,7 @@ def examples(session):
 @nox.session
 def notebooks(session):
     """Run the Jupyter notebooks."""
+    session.install("setuptools", "wheel")
     session.install("-e", ".[all,dev]", silent=False)
     if PYBOP_SCHEDULED:
         session.run("pip", "install", f"pybamm=={PYBAMM_VERSION}", silent=False)
@@ -92,6 +100,7 @@ def run_doc_tests(session):
     Checks if the documentation can be built, runs any doctests (currently not
     used).
     """
+    session.install("setuptools", "wheel")
     session.install("-e", ".[plot,docs,dev]", silent=False)
     session.run("pytest", "--docs", "-n", "0")
 
@@ -103,6 +112,7 @@ def lint(session):
 
     Credit: PyBaMM Team
     """
+    session.install("setuptools", "wheel")
     session.install("pre-commit", silent=False)
     session.run("pre-commit", "run", "--all-files")
 
@@ -121,6 +131,7 @@ def run_quick(session):
 @nox.session
 def benchmarks(session):
     """Run the benchmarks."""
+    session.install("setuptools", "wheel")
     session.install("-e", ".[all,dev]", silent=False)
     session.install("asv[virtualenv]")
     session.run("asv", "run", "--show-stderr", "--python=same")
@@ -132,6 +143,7 @@ def docs(session):
     Build the documentation and load it in a browser tab, rebuilding on changes.
     Credit: PyBaMM Team
     """
+    session.install("setuptools", "wheel")
     envbindir = session.bin
     session.install("-e", ".[all,docs]", silent=False)
     session.chdir("docs")


### PR DESCRIPTION
# Description

This PR is a small update to `noxfile.py` where the `nox` configuration is updated to install seed packages that can be sometimes missing from `uv`'s virtual environments (if using `nox[uv]`). These packages are installed with `nox`, which uses `virtualenv` as the backend for creating virtual environments, and therefore this is a failsafe change to ensure that PyBaMM can be installed along with PyBOP for platforms where wheels are not available (macOS ARM wheels started to become available with PyBaMM v24.1).

## Issue reference

This change hopes to fix some of the failing scheduled tests: https://github.com/pybop-team/PyBOP/actions/runs/8999338828

## Review
Before you mark your PR as ready for review, please ensure that you've considered the following:
- Updated the [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) in reverse chronological order (newest at the top) with a concise description of the changes, including the PR number.
- Noted any breaking changes, including details on how it might impact existing functionality.

## Type of change
- [ ] New Feature: A non-breaking change that adds new functionality.
- [ ] Optimization: A code change that improves performance.
- [ ] Examples: A change to existing or additional examples.
- [x] Bug Fix: A non-breaking change that addresses an issue.
- [ ] Documentation: Updates to documentation or new documentation for new features.
- [ ] Refactoring: Non-functional changes that improve the codebase.
- [ ] Style: Non-functional changes related to code style (formatting, naming, etc).
- [ ] Testing: Additional tests to improve coverage or confirm functionality.
- [ ] Other: (Insert description of change)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All unit tests pass: `$ nox -s tests`
- [x] The documentation builds: `$ nox -s doctest`

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:
- [ ] Code is well-commented, especially in complex or unclear areas.
- [ ] Added tests that prove my fix is effective or that my feature works.
- [ ] Checked that coverage remains or improves, and added tests if necessary to maintain or increase coverage.

Thank you for contributing to our project! Your efforts help us to deliver great software.
