### PR TITLE
Fix default option setting in quick_plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ codesigned binaries and source distributions via `sigstore-python`.
 
 ## Bug Fixes
 
+- [#330](https://github.com/pybop-team/PyBOP/issues/330) - Fixes implementation of default plotting options.
 - [#317](https://github.com/pybop-team/PyBOP/pull/317) - Installs seed packages into `nox` sessions, ensuring that scheduled tests can pass.
 - [#308](https://github.com/pybop-team/PyBOP/pull/308) - Enables testing on both macOS Intel and macOS ARM (Silicon) runners and fixes the scheduled tests.
 - [#299](https://github.com/pybop-team/PyBOP/pull/299) - Bugfix multiprocessing support for Linux, MacOS, Windows (WSL) and improves coverage.

--- a/pybop/plotting/quick_plot.py
+++ b/pybop/plotting/quick_plot.py
@@ -57,8 +57,8 @@ class StandardPlot:
         x,
         y,
         layout=None,
-        layout_options=DEFAULT_LAYOUT_OPTIONS,
-        trace_options=DEFAULT_TRACE_OPTIONS,
+        layout_options=DEFAULT_LAYOUT_OPTIONS.copy(),
+        trace_options=DEFAULT_TRACE_OPTIONS.copy(),
         trace_names=None,
         trace_name_width=40,
     ):
@@ -66,7 +66,7 @@ class StandardPlot:
         self.y = y
         self.layout = layout
         self.layout_options = layout_options
-        self.trace_options = DEFAULT_TRACE_OPTIONS
+        self.trace_options = DEFAULT_TRACE_OPTIONS.copy()
         if trace_options is not None:
             for arg, value in trace_options.items():
                 self.trace_options[arg] = value
@@ -246,9 +246,9 @@ class StandardSubplot(StandardPlot):
         num_cols=None,
         axis_titles=None,
         layout=None,
-        layout_options=DEFAULT_LAYOUT_OPTIONS,
-        subplot_options=DEFAULT_SUBPLOT_OPTIONS,
-        trace_options=DEFAULT_SUBPLOT_TRACE_OPTIONS,
+        layout_options=DEFAULT_LAYOUT_OPTIONS.copy(),
+        subplot_options=DEFAULT_SUBPLOT_OPTIONS.copy(),
+        trace_options=DEFAULT_SUBPLOT_TRACE_OPTIONS.copy(),
         trace_names=None,
         trace_name_width=40,
     ):
@@ -267,7 +267,7 @@ class StandardSubplot(StandardPlot):
         elif self.num_cols is None:
             self.num_cols = int(math.ceil(self.num_traces / self.num_rows))
         self.axis_titles = axis_titles
-        self.subplot_options = DEFAULT_SUBPLOT_OPTIONS
+        self.subplot_options = DEFAULT_SUBPLOT_OPTIONS.copy()
         if subplot_options is not None:
             for arg, value in subplot_options.items():
                 self.subplot_options[arg] = value


### PR DESCRIPTION
# Description

Fix a bug in the implementation of the default plotting options.

## Issue reference
Fixes #330

## Review
Before you mark your PR as ready for review, please ensure that you've considered the following:
- Updated the [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) in reverse chronological order (newest at the top) with a concise description of the changes, including the PR number.
- Noted any breaking changes, including details on how it might impact existing functionality.

## Type of change
- [ ] New Feature: A non-breaking change that adds new functionality.
- [ ] Optimization: A code change that improves performance.
- [ ] Examples: A change to existing or additional examples.
- [x] Bug Fix: A non-breaking change that addresses an issue.
- [ ] Documentation: Updates to documentation or new documentation for new features.
- [ ] Refactoring: Non-functional changes that improve the codebase.
- [ ] Style: Non-functional changes related to code style (formatting, naming, etc).
- [ ] Testing: Additional tests to improve coverage or confirm functionality.
- [ ] Other: (Insert description of change)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All unit tests pass: `$ nox -s tests`
- [ ] The documentation builds: `$ nox -s doctest`

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:
- [ ] Code is well-commented, especially in complex or unclear areas.
- [ ] Added tests that prove my fix is effective or that my feature works.
- [ ] Checked that coverage remains or improves, and added tests if necessary to maintain or increase coverage.

Thank you for contributing to our project! Your efforts help us to deliver great software.
