### PR TITLE
Fix failing scheduled test on MSMR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ## Bug Fixes
 
+- [#347](https://github.com/pybop-team/PyBOP/issues/347) - Resets options between MSMR tests to cope with a bug in PyBaMM v23.9 which is fixed in PyBaMM v24.1.
 - [#337](https://github.com/pybop-team/PyBOP/issues/337) - Restores benchmarks, relaxes CI schedule for benchmarks and scheduled tests.
 - [#231](https://github.com/pybop-team/PyBOP/issues/231) - Allows passing of keyword arguments to PyBaMM models and disables build on initialisation.
 - [#321](https://github.com/pybop-team/PyBOP/pull/321) - Improves `integration/test_spm_parameterisation.py` stability, adds flakly pytest plugin, and `test_thevenin_parameterisation.py` integration test.

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -12,24 +12,24 @@ class TestModels:
     """
 
     @pytest.mark.parametrize(
-        "model_class, expected_name",
+        "model_class, expected_name, options",
         [
-            (pybop.lithium_ion.SPM, "Single Particle Model"),
-            (pybop.lithium_ion.SPMe, "Single Particle Model with Electrolyte"),
-            (pybop.lithium_ion.DFN, "Doyle-Fuller-Newman"),
-            (pybop.lithium_ion.MPM, "Many Particle Model"),
-            (pybop.lithium_ion.MSMR, "Multi Species Multi Reactions Model"),
-            (pybop.lithium_ion.WeppnerHuggins, "Weppner & Huggins model"),
-            (pybop.empirical.Thevenin, "Equivalent Circuit Thevenin Model"),
+            (pybop.lithium_ion.SPM, "Single Particle Model", None),
+            (pybop.lithium_ion.SPMe, "Single Particle Model with Electrolyte", None),
+            (pybop.lithium_ion.DFN, "Doyle-Fuller-Newman", None),
+            (pybop.lithium_ion.MPM, "Many Particle Model", None),
+            (
+                pybop.lithium_ion.MSMR,
+                "Multi Species Multi Reactions Model",
+                {"number of MSMR reactions": ("6", "4")},
+            ),
+            (pybop.lithium_ion.WeppnerHuggins, "Weppner & Huggins model", None),
+            (pybop.empirical.Thevenin, "Equivalent Circuit Thevenin Model", None),
         ],
     )
     @pytest.mark.unit
-    def test_model_classes(self, model_class, expected_name):
-        options = None
-        if model_class is pybop.lithium_ion.MSMR:
-            options = {"number of MSMR reactions": ("6", "4")}
+    def test_model_classes(self, model_class, expected_name, options):
         model = model_class(options=options)
-
         assert model.pybamm_model is not None
         assert model.name == expected_name
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -34,6 +34,9 @@ class TestModels:
         assert model.name == expected_name
 
         # Test initialisation with kwargs
+        if model_class is pybop.lithium_ion.MSMR:
+            # Reset the options to cope with a bug in PyBaMM v23.9 msmr.py:23 which is fixed in v24.1
+            options = {"number of MSMR reactions": ("6", "4")}
         parameter_set = pybop.ParameterSet(
             params_dict={"Nominal cell capacity [A.h]": 5}
         )


### PR DESCRIPTION
# Description

Fix a bug that causes one of the MSMR tests to fail by resetting the model options dictionary.

## Issue reference
Fixes #347 

## Review
Before you mark your PR as ready for review, please ensure that you've considered the following:
- Updated the [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) in reverse chronological order (newest at the top) with a concise description of the changes, including the PR number.
- Noted any breaking changes, including details on how it might impact existing functionality.

## Type of change
- [ ] New Feature: A non-breaking change that adds new functionality.
- [ ] Optimization: A code change that improves performance.
- [ ] Examples: A change to existing or additional examples.
- [ ] Bug Fix: A non-breaking change that addresses an issue.
- [ ] Documentation: Updates to documentation or new documentation for new features.
- [ ] Refactoring: Non-functional changes that improve the codebase.
- [ ] Style: Non-functional changes related to code style (formatting, naming, etc).
- [ ] Testing: Additional tests to improve coverage or confirm functionality.
- [ ] Other: (Insert description of change)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All unit tests pass: `$ nox -s tests`
- [ ] The documentation builds: `$ nox -s doctest`

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:
- [ ] Code is well-commented, especially in complex or unclear areas.
- [ ] Added tests that prove my fix is effective or that my feature works.
- [ ] Checked that coverage remains or improves, and added tests if necessary to maintain or increase coverage.

Thank you for contributing to our project! Your efforts help us to deliver great software.
