### PR TITLE
Adds SLF001 to ruff - private object access

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ pip install -e .[all,dev]
 
 Before you commit any code, please perform the following checks using [Nox](https://nox.thea.codes/en/stable/index.html):
 
-- [All tests pass](#testing): `$ nox -s unit`
+- [All tests pass](#testing): `$ nox -s quick`
 
 ### Installing and using pre-commit
 
@@ -83,16 +83,18 @@ PyBOP follows the [PEP8 recommendations](https://www.python.org/dev/peps/pep-000
 
 ### Ruff
 
-We use [ruff](https://github.com/charliermarsh/ruff) to check our PEP8 adherence. To try this on your system, navigate to the PyBOP directory in a console and type
+We use [ruff](https://github.com/charliermarsh/ruff) to lint and ensure adherence to Python PEP standards. To manually trigger `ruff`, navigate to the PyBOP directory in a console and type
 
 ```bash
 python -m pip install pre-commit
 pre-commit run ruff
 ```
 
-ruff is configured inside the file `pre-commit-config.yaml`, allowing us to ignore some errors. If you think this should be added or removed, please submit an [issue](https://guides.github.com/features/issues/).
+ruff is configured inside the file `pyproject.toml`, allowing us to ignore some errors. If you think a rule should be added or removed, please submit an [issue](https://guides.github.com/features/issues/).
 
-When you commit your changes they will be checked against ruff automatically (see [Pre-commit checks](#pre-commit-checks)).
+When you commit your changes they will be checked against ruff automatically (see [Pre-commit checks](#pre-commit-checks)). If you are having issues getting your commit to pass the linting, it
+is possible to skip linting for single lines (this should only be done as a **last resort**) by adding a line comment of `#noqa: $ruff_rule` where the `$ruff_rule` is replaced with the rule in question.
+These rules can be found in the ruff configuration in `pyproject.toml` or in the failed pre-commit output. Please note the lint skipping in the pull request for reviewers.
 
 ### Naming
 

--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -79,7 +79,7 @@ class BenchmarkModel:
             model (pybop.Model): The model class being benchmarked.
             parameter_set (str): The name of the parameter set being used.
         """
-        self.problem._model.simulate(inputs=self.inputs, t_eval=self.t_eval)
+        self.problem.model.simulate(inputs=self.inputs, t_eval=self.t_eval)
 
     def time_model_simulateS1(self, model, parameter_set):
         """
@@ -89,4 +89,4 @@ class BenchmarkModel:
             model (pybop.Model): The model class being benchmarked.
             parameter_set (str): The name of the parameter set being used.
         """
-        self.problem._model.simulateS1(inputs=self.inputs, t_eval=self.t_eval)
+        self.problem.model.simulateS1(inputs=self.inputs, t_eval=self.t_eval)

--- a/examples/notebooks/optimiser_calibration.ipynb
+++ b/examples/notebooks/optimiser_calibration.ipynb
@@ -482,7 +482,7 @@
    "source": [
     "for optim, sigma in zip(optims, sigmas):\n",
     "    print(\n",
-    "        f\"| Sigma: {sigma} | Num Iterations: {optim._iterations} | Best Cost: {optim.pints_optimiser.f_best()} | Results: {optim.pints_optimiser.x_best()} |\"\n",
+    "        f\"| Sigma: {sigma} | Num Iterations: {optim.iterations} | Best Cost: {optim.pints_optimiser.f_best()} | Results: {optim.pints_optimiser.x_best()} |\"\n",
     "    )"
    ]
   },

--- a/examples/notebooks/spm_electrode_design.ipynb
+++ b/examples/notebooks/spm_electrode_design.ipynb
@@ -276,7 +276,7 @@
    ],
    "source": [
     "if cost.update_capacity:\n",
-    "    problem._model.approximate_capacity(x)\n",
+    "    problem.model.approximate_capacity(x)\n",
     "pybop.quick_plot(problem, problem_inputs=x, title=\"Optimised Comparison\");"
    ]
   },

--- a/examples/scripts/exp_UKF.py
+++ b/examples/scripts/exp_UKF.py
@@ -40,7 +40,7 @@ expected_values = (
 # Verification step: make another prediction using the Observer class
 model.build(parameters=parameters)
 simulator = pybop.Observer(parameters, model, signal=["2y"])
-simulator._time_data = t_eval
+simulator.time_data = t_eval
 measurements = simulator.evaluate(true_inputs)
 
 # Verification step: Compare by plotting

--- a/examples/scripts/spme_max_energy.py
+++ b/examples/scripts/spme_max_energy.py
@@ -57,7 +57,7 @@ print(f"Optimised volumetric energy density: {cost2(x):.2f} Wh.m-3")
 
 # Plot the timeseries output
 if cost.update_capacity:
-    problem._model.approximate_capacity(x)
+    problem.model.approximate_capacity(x)
 pybop.quick_plot(problem, problem_inputs=x, title="Optimised Comparison")
 
 # Plot the cost landscape with optimisation path

--- a/examples/standalone/cost.py
+++ b/examples/standalone/cost.py
@@ -43,9 +43,9 @@ class StandaloneCost(pybop.BaseCost):
         )
         self.x0 = self.parameters.initial_value()
 
-    def _evaluate(self, inputs):
+    def compute(self, inputs):
         """
-        Calculate the cost for a given parameter value.
+        Compute the cost for a given parameter value.
 
         The cost function is defined as cost(x) = x^2 + 42, where x is the
         parameter value.

--- a/pybop/costs/_likelihoods.py
+++ b/pybop/costs/_likelihoods.py
@@ -279,7 +279,7 @@ class MAP(BaseLikelihood):
             raise ValueError(f"{self.likelihood} must be a subclass of BaseLikelihood")
 
         self.parameters = self.likelihood.parameters
-        self._has_separable_problem = self.likelihood._has_separable_problem
+        self._has_separable_problem = self.likelihood.has_separable_problem
 
     def _evaluate(self, inputs: Inputs) -> float:
         """

--- a/pybop/costs/_likelihoods.py
+++ b/pybop/costs/_likelihoods.py
@@ -39,10 +39,13 @@ class GaussianLogLikelihoodKnownSigma(BaseLikelihood):
         self._offset = -0.5 * self.n_time_data * np.log(2 * np.pi * self.sigma2)
         self._multip = -1 / (2.0 * self.sigma2)
 
-    def _evaluate(self, inputs: Inputs) -> float:
+    def compute(self, inputs: Inputs) -> float:
         """
-        Evaluates the Gaussian log-likelihood for the given parameters with known sigma.
+        Compute the Gaussian log-likelihood for the given parameters with known sigma.
+
+        This method only computes the likelihood, without calling the problem.evaluateS1.
         """
+
         if not self.verify_prediction(self.y):
             return -np.inf
 
@@ -59,14 +62,16 @@ class GaussianLogLikelihoodKnownSigma(BaseLikelihood):
 
         return e.item() if self.n_outputs == 1 else np.sum(e)
 
-    def _evaluateS1(self, inputs: Inputs) -> tuple[float, np.ndarray]:
+    def computeS1(self, inputs: Inputs) -> tuple[float, np.ndarray]:
         """
-        Calculates the log-likelihood and gradient.
+        Compute the Gaussian log-likelihood and it's gradient for the given parameters with known sigma.
+
+        This method only computes the likelihood, without calling the problem.evaluateS1.
         """
         if not self.verify_prediction(self.y):
             return -np.inf, -self._de * np.ones(self.n_parameters)
 
-        likelihood = self._evaluate(inputs)
+        likelihood = self.compute(inputs)
 
         r = np.asarray(
             [self._target[signal] - self.y[signal] for signal in self.signal]
@@ -168,9 +173,11 @@ class GaussianLogLikelihood(BaseLikelihood):
             raise ValueError("dsigma_scale must be non-negative")
         self._dsigma_scale = new_value
 
-    def _evaluate(self, inputs: Inputs) -> float:
+    def compute(self, inputs: Inputs) -> float:
         """
-        Evaluates the Gaussian log-likelihood for the given parameters.
+        Compute the Gaussian log-likelihood for the given parameters.
+
+        This method only computes the likelihood, without calling the problem.evaluateS1.
 
         Parameters
         ----------
@@ -207,9 +214,11 @@ class GaussianLogLikelihood(BaseLikelihood):
 
         return e.item() if self.n_outputs == 1 else np.sum(e)
 
-    def _evaluateS1(self, inputs: Inputs) -> tuple[float, np.ndarray]:
+    def computeS1(self, inputs: Inputs) -> tuple[float, np.ndarray]:
         """
-        Calculates the log-likelihood and sensitivities.
+        Compute the Gaussian log-likelihood and it's gradient for the given parameters.
+
+        This method only computes the likelihood, without calling the problem.evaluateS1.
 
         Parameters
         ----------
@@ -231,7 +240,7 @@ class GaussianLogLikelihood(BaseLikelihood):
         if not self.verify_prediction(self.y):
             return -np.inf, -self._de * np.ones(self.n_parameters)
 
-        likelihood = self._evaluate(inputs)
+        likelihood = self.compute(inputs)
 
         r = np.asarray(
             [self._target[signal] - self.y[signal] for signal in self.signal]
@@ -281,14 +290,18 @@ class MAP(BaseLikelihood):
         self.parameters = self.likelihood.parameters
         self._has_separable_problem = self.likelihood.has_separable_problem
 
-    def _evaluate(self, inputs: Inputs) -> float:
+    def compute(self, inputs: Inputs) -> float:
         """
-        Calculate the maximum a posteriori cost for a given set of parameters.
+        Compute the Maximum a Posteriori for the given parameters.
+
+        If self._has_separable_problem is True, then this method only computes the
+        likelihood, without calling the problem.evaluate(). Else, problem.evaluate()
+        is called before computing the likelihood.
 
         Parameters
         ----------
         inputs : Inputs
-            The parameters for which to evaluate the cost.
+            The parameters for which to compute the cost.
 
         Returns
         -------
@@ -309,10 +322,13 @@ class MAP(BaseLikelihood):
         posterior = log_likelihood + log_prior
         return posterior
 
-    def _evaluateS1(self, inputs: Inputs) -> tuple[float, np.ndarray]:
+    def computeS1(self, inputs: Inputs) -> tuple[float, np.ndarray]:
         """
-        Compute the maximum a posteriori with respect to the parameters.
-        The method passes the likelihood gradient to the optimiser without modification.
+        Compute the Maximum a Posteriori, and it's gradient for the given parameters.
+
+        If self._has_separable_problem is True, then this method only computes the
+        likelihood, without calling the problem.evaluateS1(). Else, problem.evaluateS1()
+        is called before computing the likelihood.
 
         Parameters
         ----------

--- a/pybop/costs/_weighted_cost.py
+++ b/pybop/costs/_weighted_cost.py
@@ -22,7 +22,7 @@ class WeightedCost(BaseCost):
         A list of values with which to weight the cost values.
     _has_identical_problems : bool
         If True, the shared problem will be evaluated once and saved before the
-        self._evaluate() method of each cost is called (default: False).
+        self.compute() method of each cost is called (default: False).
     _has_separable_problem: bool
         If True, the shared problem is seperable from the cost function and
         will be evaluated for each problem before the cost evaluation is
@@ -80,9 +80,9 @@ class WeightedCost(BaseCost):
         # Weighted costs do not use this functionality
         self._has_separable_problem = False
 
-    def _evaluate(self, inputs: Inputs):
+    def compute(self, inputs: Inputs):
         """
-        Calculate the weighted cost for a given set of parameters.
+        Compute the weighted cost for a given set of parameters.
 
         Parameters
         ----------
@@ -109,11 +109,11 @@ class WeightedCost(BaseCost):
                 cost.y = cost.problem.evaluate(
                     inputs, update_capacity=self.update_capacity
                 )
-            e[i] = cost._evaluate(inputs)
+            e[i] = cost.compute(inputs)
 
         return np.dot(e, self.weights)
 
-    def _evaluateS1(self, inputs: Inputs):
+    def computeS1(self, inputs: Inputs):
         """
         Compute the weighted cost and its gradient with respect to the parameters.
 
@@ -142,7 +142,7 @@ class WeightedCost(BaseCost):
                 cost.y, cost.dy = (self.y, self.dy)
             elif cost.has_separable_problem:
                 cost.y, cost.dy = cost.problem.evaluateS1(inputs)
-            e[i], de[:, i] = cost._evaluateS1(inputs)
+            e[i], de[:, i] = cost.computeS1(inputs)
 
         e = np.dot(e, self.weights)
         de = np.dot(de, self.weights)

--- a/pybop/costs/_weighted_cost.py
+++ b/pybop/costs/_weighted_cost.py
@@ -54,7 +54,7 @@ class WeightedCost(BaseCost):
 
         # Check if all costs depend on the same problem
         self._has_identical_problems = all(
-            cost._has_separable_problem and cost.problem is self.costs[0].problem
+            cost.has_separable_problem and cost.problem is self.costs[0].problem
             for cost in self.costs
         )
 
@@ -105,7 +105,7 @@ class WeightedCost(BaseCost):
             inputs = cost.parameters.as_dict()
             if self._has_identical_problems:
                 cost.y = self.y
-            elif cost._has_separable_problem:
+            elif cost.has_separable_problem:
                 cost.y = cost.problem.evaluate(
                     inputs, update_capacity=self.update_capacity
                 )
@@ -140,7 +140,7 @@ class WeightedCost(BaseCost):
             inputs = cost.parameters.as_dict()
             if self._has_identical_problems:
                 cost.y, cost.dy = (self.y, self.dy)
-            elif cost._has_separable_problem:
+            elif cost.has_separable_problem:
                 cost.y, cost.dy = cost.problem.evaluateS1(inputs)
             e[i], de[:, i] = cost._evaluateS1(inputs)
 

--- a/pybop/costs/base_cost.py
+++ b/pybop/costs/base_cost.py
@@ -24,7 +24,7 @@ class BaseCost:
         The number of outputs in the model.
     _has_separable_problem : bool
         If True, the problem is separable from the cost function and will be
-        evaluated in advance of the call to self._evaluate() (default: False).
+        evaluated in advance of the call to self.compute() (default: False).
     """
 
     def __init__(self, problem: Optional[BaseProblem] = None):
@@ -65,7 +65,8 @@ class BaseCost:
 
     def evaluate(self, inputs: Union[Inputs, list]):
         """
-        Call the evaluate function for a given set of parameters.
+        This method calls the forward model via problem.evaluateS1(inputs),
+        and computes the cost for the given output by calling self.computeS1(inputs).
 
         Parameters
         ----------
@@ -92,7 +93,7 @@ class BaseCost:
                     inputs, update_capacity=self.update_capacity
                 )
 
-            return self._evaluate(inputs)
+            return self.compute(inputs)
 
         except NotImplementedError as e:
             raise e
@@ -100,16 +101,17 @@ class BaseCost:
         except Exception as e:
             raise ValueError(f"Error in cost calculation: {e}") from e
 
-    def _evaluate(self, inputs: Inputs):
+    def compute(self, inputs: Inputs):
         """
-        Calculate the cost function value for a given set of parameters.
+        Calculates the cost function value for a given set of parameters.
 
+        This method only computes the cost, without calling the problem.evaluate.
         This method must be implemented by subclasses.
 
         Parameters
         ----------
         inputs : Inputs
-            The parameters for which to evaluate the cost.
+            The parameters for which to compute the cost.
 
         Returns
         -------
@@ -125,12 +127,17 @@ class BaseCost:
 
     def evaluateS1(self, inputs: Union[Inputs, list]):
         """
-        Call _evaluateS1 for a given set of parameters.
+        This method calls the forward model via problem.evaluateS1(inputs),
+        and computes the cost for the given output by calling self.computeS1(inputs).
+
+        This method includes the gradient of the cost function computed by
+        calling self.computeS1(inputs) with the sensitivity information provided by
+        the forward model via problem.evaluateS1(inputs).
 
         Parameters
         ----------
         inputs : Inputs or array-like
-            The parameters for which to compute the cost and gradient.
+            The parameters for which to evaluate the cost and gradient.
 
         Returns
         -------
@@ -151,7 +158,7 @@ class BaseCost:
             if self._has_separable_problem:
                 self.y, self.dy = self.problem.evaluateS1(inputs)
 
-            return self._evaluateS1(inputs)
+            return self.computeS1(inputs)
 
         except NotImplementedError as e:
             raise e
@@ -159,9 +166,12 @@ class BaseCost:
         except Exception as e:
             raise ValueError(f"Error in cost calculation: {e}") from e
 
-    def _evaluateS1(self, inputs: Inputs):
+    def computeS1(self, inputs: Inputs):
         """
         Compute the cost and its gradient with respect to the parameters.
+
+        This method only computes the cost, without calling the problem.evaluateS1.
+        This method must be implemented by subclasses.
 
         Parameters
         ----------

--- a/pybop/costs/base_cost.py
+++ b/pybop/costs/base_cost.py
@@ -38,7 +38,7 @@ class BaseCost:
         self.dy = None
         self.set_fail_gradient()
         if isinstance(self.problem, BaseProblem):
-            self._target = self.problem._target
+            self._target = self.problem.target
             self.parameters.join(self.problem.parameters)
             self.n_outputs = self.problem.n_outputs
             self.signal = self.problem.signal
@@ -52,6 +52,10 @@ class BaseCost:
     @property
     def has_separable_problem(self):
         return self._has_separable_problem
+
+    @property
+    def target(self):
+        return self._target
 
     def __call__(self, inputs: Union[Inputs, list]):
         """

--- a/pybop/costs/design_costs.py
+++ b/pybop/costs/design_costs.py
@@ -61,8 +61,8 @@ class DesignCost(BaseCost):
 
         if "Time [s]" not in solution:
             raise ValueError("The solution does not contain time data.")
-        self.problem._time_data = solution["Time [s]"]
-        self.problem._target = {key: solution[key] for key in self.problem.signal}
+        self.problem.time_data = solution["Time [s]"]
+        self.problem.target = {key: solution[key] for key in self.problem.signal}
         self.dt = solution["Time [s]"][1] - solution["Time [s]"][0]
 
 

--- a/pybop/costs/design_costs.py
+++ b/pybop/costs/design_costs.py
@@ -78,11 +78,11 @@ class GravimetricEnergyDensity(DesignCost):
 
     def __init__(self, problem, update_capacity=False):
         super().__init__(problem, update_capacity)
-        self._fixed_problem = False  # keep problem evaluation within _evaluate
+        self._fixed_problem = False  # keep problem evaluation within compute
 
-    def _evaluate(self, inputs: Inputs):
+    def compute(self, inputs: Inputs):
         """
-        Computes the cost function for the energy density.
+        Computes the cost function for the given parameters.
 
         Parameters
         ----------
@@ -118,9 +118,9 @@ class VolumetricEnergyDensity(DesignCost):
     def __init__(self, problem, update_capacity=False):
         super().__init__(problem, update_capacity)
 
-    def _evaluate(self, inputs: Inputs):
+    def compute(self, inputs: Inputs):
         """
-        Computes the cost function for the energy density.
+        Computes the cost function for the given parameters.
 
         Parameters
         ----------

--- a/pybop/costs/fitting_costs.py
+++ b/pybop/costs/fitting_costs.py
@@ -20,9 +20,11 @@ class RootMeanSquaredError(BaseCost):
     def __init__(self, problem):
         super().__init__(problem)
 
-    def _evaluate(self, inputs: Inputs):
+    def compute(self, inputs: Inputs):
         """
-        Calculate the root mean square error for a given set of parameters.
+        Compute the cost and its gradient with respect to the parameters.
+
+        This method only computes the cost, without calling the problem.evaluate().
 
         Parameters
         ----------
@@ -50,9 +52,11 @@ class RootMeanSquaredError(BaseCost):
 
         return e.item() if self.n_outputs == 1 else np.sum(e)
 
-    def _evaluateS1(self, inputs: Inputs):
+    def computeS1(self, inputs: Inputs):
         """
         Compute the cost and its gradient with respect to the parameters.
+
+        This method only computes the cost, without calling the problem.evaluateS1().
 
         Parameters
         ----------
@@ -106,9 +110,11 @@ class SumSquaredError(BaseCost):
     def __init__(self, problem):
         super().__init__(problem)
 
-    def _evaluate(self, inputs: Inputs):
+    def compute(self, inputs: Inputs):
         """
-        Calculate the sum of squared errors for a given set of parameters.
+        Compute the cost and its gradient with respect to the parameters.
+
+        This method only computes the cost, without calling the problem.evaluate().
 
         Parameters
         ----------
@@ -132,9 +138,11 @@ class SumSquaredError(BaseCost):
 
         return e.item() if self.n_outputs == 1 else np.sum(e)
 
-    def _evaluateS1(self, inputs: Inputs):
+    def computeS1(self, inputs: Inputs):
         """
         Compute the cost and its gradient with respect to the parameters.
+
+        This method only computes the cost, without calling the problem.evaluateS1().
 
         Parameters
         ----------
@@ -205,9 +213,11 @@ class Minkowski(BaseCost):
             )
         self.p = float(p)
 
-    def _evaluate(self, inputs: Inputs, grad=None):
+    def compute(self, inputs: Inputs, grad=None):
         """
-        Calculate the Minkowski cost for a given set of parameters.
+        Compute the cost with respect to the parameters.
+
+        This method only computes the cost, without calling the problem.evaluate().
 
         Parameters
         ----------
@@ -232,9 +242,11 @@ class Minkowski(BaseCost):
 
         return e.item() if self.n_outputs == 1 else np.sum(e)
 
-    def _evaluateS1(self, inputs):
+    def computeS1(self, inputs):
         """
         Compute the cost and its gradient with respect to the parameters.
+
+        This method only computes the cost, without calling the problem.evaluateS1().
 
         Parameters
         ----------
@@ -312,9 +324,11 @@ class SumofPower(BaseCost):
             raise ValueError("p = np.inf is not yet supported.")
         self.p = float(p)
 
-    def _evaluate(self, inputs: Inputs, grad=None):
+    def compute(self, inputs: Inputs, grad=None):
         """
-        Calculate the Sum of Power cost for a given set of parameters.
+        Compute the cost with respect to the parameters.
+
+        This method only computes the cost, without calling the problem.evaluate().
 
         Parameters
         ----------
@@ -338,9 +352,11 @@ class SumofPower(BaseCost):
 
         return e.item() if self.n_outputs == 1 else np.sum(e)
 
-    def _evaluateS1(self, inputs):
+    def computeS1(self, inputs):
         """
         Compute the cost and its gradient with respect to the parameters.
+
+        This method only computes the cost, without calling the problem.evaluateS1().
 
         Parameters
         ----------
@@ -386,7 +402,7 @@ class ObserverCost(BaseCost):
         self._observer = observer
         self._has_separable_problem = False
 
-    def _evaluate(self, inputs: Inputs):
+    def compute(self, inputs: Inputs):
         """
         Calculate the observer cost for a given set of parameters.
 
@@ -408,9 +424,11 @@ class ObserverCost(BaseCost):
         )
         return -log_likelihood
 
-    def _evaluateS1(self, inputs: Inputs):
+    def computeS1(self, inputs: Inputs):
         """
         Compute the cost and its gradient with respect to the parameters.
+
+        This method only computes the cost, without calling the problem.evaluateS1().
 
         Parameters
         ----------

--- a/pybop/costs/fitting_costs.py
+++ b/pybop/costs/fitting_costs.py
@@ -404,7 +404,7 @@ class ObserverCost(BaseCost):
             The observer cost (negative of the log likelihood).
         """
         log_likelihood = self._observer.log_likelihood(
-            self._target, self._observer.time_data(), inputs
+            self._target, self._observer.time_data, inputs
         )
         return -log_likelihood
 

--- a/pybop/models/base_model.py
+++ b/pybop/models/base_model.py
@@ -114,7 +114,7 @@ class BaseModel:
             self._built_model = self.pybamm_model
 
         else:
-            if not self.pybamm_model._built:
+            if not self.pybamm_model._built:  # noqa: SLF001
                 self.pybamm_model.build_model()
             self.set_params()
 
@@ -129,7 +129,7 @@ class BaseModel:
             )
 
             # Clear solver and setup model
-            self._solver._model_set_up = {}
+            self._solver._model_set_up = {}  # noqa: SLF001
 
         self.n_states = self._built_model.len_rhs_and_alg  # len_rhs + len_alg
 
@@ -244,7 +244,7 @@ class BaseModel:
         )
 
         # Clear solver and setup model
-        self._solver._model_set_up = {}
+        self._solver._model_set_up = {}  # noqa: SLF001
 
     def classify_and_update_parameters(self, parameters: Parameters):
         """
@@ -506,7 +506,7 @@ class BaseModel:
         """
         inputs = self.parameters.verify(inputs)
 
-        if not self.pybamm_model._built:
+        if not self.pybamm_model._built:  # noqa: SLF001
             self.pybamm_model.build_model()
 
         parameter_set = parameter_set or self._unprocessed_parameter_set
@@ -659,17 +659,30 @@ class BaseModel:
     def built_model(self):
         return self._built_model
 
+    @built_model.setter
+    def built_model(self, built_model):
+        self._built_model = built_model if built_model is not None else None
+
+    def built_initial_soc(self):
+        return self._built_initial_soc
+
     @property
     def parameter_set(self):
         return self._parameter_set
 
     @parameter_set.setter
     def parameter_set(self, parameter_set):
-        self._parameter_set = parameter_set.copy()
+        self._parameter_set = parameter_set.copy() if parameter_set is not None else {}
 
     @property
     def model_with_set_params(self):
         return self._model_with_set_params
+
+    @model_with_set_params.setter
+    def model_with_set_params(self, model_with_set_params):
+        self._model_with_set_params = (
+            model_with_set_params.copy() if model_with_set_params is not None else None
+        )
 
     @property
     def geometry(self):
@@ -692,6 +705,18 @@ class BaseModel:
     @property
     def mesh(self):
         return self._mesh
+
+    @mesh.setter
+    def mesh(self, mesh):
+        self._mesh = mesh if mesh is not None else None
+
+    @property
+    def disc(self):
+        return self._disc
+
+    @disc.setter
+    def disc(self, disc):
+        self._disc = disc if disc is not None else None
 
     @property
     def var_pts(self):
@@ -723,7 +748,7 @@ class BaseModel:
         """
         Extracts the parameter names and types and returns them as a dictionary.
         """
-        if not self.pybamm_model._built:
+        if not self.pybamm_model._built:  # noqa: SLF001
             self.pybamm_model.build_model()
 
         info = self.pybamm_model.get_parameter_info()

--- a/pybop/observers/observer.py
+++ b/pybop/observers/observer.py
@@ -49,7 +49,7 @@ class Observer(BaseProblem):
         super().__init__(
             parameters, model, check_model, signal, additional_variables, init_soc
         )
-        if model._built_model is None:
+        if model.built_model is None:
             raise ValueError("Only built models can be used in Observers")
         if model.signal is None:
             model.signal = self.signal

--- a/pybop/optimisers/_adamw.py
+++ b/pybop/optimisers/_adamw.py
@@ -26,7 +26,7 @@ class AdamWImpl(PintsOptimiser):
         m_j' = m_j[i] / (1 - beta1**(1 + i))
         v_j' = v_j[i] / (1 - beta2**(1 + i))
 
-        p_j[i] = p_j[i - 1] - alpha * (m_j' / (sqrt(v_j') + eps) + lambda * p_j[i - 1])
+        p_j[i] = p_j[i - 1] - alpha * (m_j' / (sqrt(v_j') + eps) + lam * p_j[i - 1])
 
     The initial values of the moments are ``m_j[0] = v_j[0] = 0``, after which
     they decay with rates ``beta1`` and ``beta2``. The default values for these are,
@@ -38,7 +38,7 @@ class AdamWImpl(PintsOptimiser):
     The parameter ``alpha`` is a step size, which is set as ``min(sigma0)`` in
     this implementation.
 
-    The parameter ``lambda`` is the weight decay rate, which is set to ``0.01``
+    The parameter ``lam`` is the weight decay rate, which is set to ``0.01``
     by default in this implementation.
 
     Finally, ``eps`` is a small constant used to avoid division by zero, set to
@@ -89,7 +89,7 @@ class AdamWImpl(PintsOptimiser):
         self._alpha = np.min(self._sigma0)
 
         # Weight decay rate
-        self.set_lambda()
+        self._lam = 0.01
 
         # Small number added to avoid divide-by-zero
         self._eps = np.finfo(float).eps
@@ -186,7 +186,7 @@ class AdamWImpl(PintsOptimiser):
 
         # Take step with weight decay
         self._proposed = self._current - self._alpha * (
-            m / (np.sqrt(v) + self._eps) + self._lambda * self._current
+            m / (np.sqrt(v) + self._eps) + self._lam * self._current
         )
 
         # Update x_best and f_best
@@ -206,17 +206,27 @@ class AdamWImpl(PintsOptimiser):
         """
         return self._current
 
-    def set_lambda(self, lambda_: float = 0.01) -> None:
+    @property
+    def lam(self):
+        return self._lam
+
+    @lam.setter
+    def lam(self, lam: float = 0.01) -> None:
         """
-        Sets the lambda_ decay constant. This is the weight decay rate
+        Sets the lam decay constant. This is the weight decay rate
         that helps in finding the optimal solution.
         """
-        if not isinstance(lambda_, (int, float)) or not 0 < lambda_ <= 1:
-            raise ValueError("lambda_ must be a numeric value between 0 and 1.")
+        if not isinstance(lam, (int, float)) or not 0 < lam <= 1:
+            raise ValueError("lam must be a numeric value between 0 and 1.")
 
-        self._lambda = float(lambda_)
+        self._lam = float(lam)
 
-    def set_b1(self, b1: float) -> None:
+    @property
+    def b1(self):
+        return self._b1
+
+    @b1.setter
+    def b1(self, b1: float) -> None:
         """
         Sets the b1 momentum decay constant.
         """
@@ -225,7 +235,12 @@ class AdamWImpl(PintsOptimiser):
 
         self._b1 = float(b1)
 
-    def set_b2(self, b2: float) -> None:
+    @property
+    def b2(self):
+        return self._b2
+
+    @b2.setter
+    def b2(self, b2: float) -> None:
         """
         Sets the b2 momentum decay constant.
         """

--- a/pybop/optimisers/base_optimiser.py
+++ b/pybop/optimisers/base_optimiser.py
@@ -222,7 +222,7 @@ class BaseOptimiser:
         x : array-like
             Optimised parameter values.
         """
-        if self.cost.problem._model.check_params(
+        if self.cost.problem.model.check_params(
             inputs=x, allow_infeasible_solutions=False
         ):
             return
@@ -259,7 +259,7 @@ class BaseOptimiser:
         self.allow_infeasible_solutions = allow
 
         if hasattr(self.cost, "problem") and hasattr(self.cost.problem, "_model"):
-            self.cost.problem._model.allow_infeasible_solutions = (
+            self.cost.problem.model.allow_infeasible_solutions = (
                 self.allow_infeasible_solutions
             )
         else:

--- a/pybop/optimisers/base_pints_optimiser.py
+++ b/pybop/optimisers/base_pints_optimiser.py
@@ -505,3 +505,7 @@ class BasePintsOptimiser(BaseOptimiser):
             self._threshold = None
         else:
             self._threshold = float(threshold)
+
+    @property
+    def iterations(self):
+        return self._iterations

--- a/pybop/optimisers/pints_optimisers.py
+++ b/pybop/optimisers/pints_optimisers.py
@@ -17,8 +17,9 @@ class GradientDescent(BasePintsOptimiser):
     Implements a simple gradient descent optimization algorithm.
 
     This class extends the gradient descent optimiser from the PINTS library, designed
-    to minimize a scalar function of one or more variables. Note that this optimiser
-    does not support boundary constraints.
+    to minimize a scalar function of one or more variables.
+
+    Note that this optimiser does not support boundary constraints.
 
     Parameters
     ----------
@@ -45,8 +46,9 @@ class Adam(BasePintsOptimiser):
     Implements the Adam optimization algorithm.
 
     This class extends the Adam optimiser from the PINTS library, which combines
-    ideas from RMSProp and Stochastic Gradient Descent with momentum. Note that
-    this optimiser does not support boundary constraints.
+    ideas from RMSProp and Stochastic Gradient Descent with momentum.
+
+    Note that this optimiser does not support boundary constraints.
 
     Parameters
     ----------
@@ -81,6 +83,7 @@ class AdamW(BasePintsOptimiser):
     robust and stable for training deep neural networks, particularly when
     using larger learning rates.
 
+    Note that this optimiser does not support boundary constraints.
     Parameters
     ----------
     **optimiser_kwargs : optional
@@ -222,6 +225,8 @@ class NelderMead(BasePintsOptimiser):
     This is a deterministic local optimiser. In most update steps it performs
     either one evaluation, or two sequential evaluations, so that it will not
     typically benefit from parallelisation.
+
+    Note that this optimiser does not support boundary constraints.
 
     Parameters
     ----------

--- a/pybop/plotting/plot_problem.py
+++ b/pybop/plotting/plot_problem.py
@@ -37,7 +37,7 @@ def quick_plot(problem, problem_inputs: Inputs = None, show=True, **layout_kwarg
         problem_inputs = problem.parameters.verify(problem_inputs)
 
     # Extract the time data and evaluate the model's output and target values
-    xaxis_data = problem.time_data()
+    xaxis_data = problem.time_data
     model_output = problem.evaluate(problem_inputs)
     target_output = problem.get_target()
 

--- a/pybop/problems/base_problem.py
+++ b/pybop/problems/base_problem.py
@@ -108,17 +108,6 @@ class BaseProblem:
         """
         raise NotImplementedError
 
-    def time_data(self):
-        """
-        Returns the time data.
-
-        Returns
-        -------
-        np.ndarray
-            The time array.
-        """
-        return self._time_data
-
     def get_target(self):
         """
         Return the target dataset.
@@ -149,3 +138,19 @@ class BaseProblem:
     @property
     def model(self):
         return self._model
+
+    @property
+    def target(self):
+        return self._target
+
+    @target.setter
+    def target(self, target):
+        self._target = target
+
+    @property
+    def time_data(self):
+        return self._time_data
+
+    @time_data.setter
+    def time_data(self, time_data):
+        self._time_data = time_data

--- a/pybop/problems/design_problem.py
+++ b/pybop/problems/design_problem.py
@@ -66,7 +66,7 @@ class DesignProblem(BaseProblem):
             # Leave the build until later to apply the experiment
             self._model.classify_and_update_parameters(self.parameters)
 
-        elif self._model._built_model is None:
+        elif self._model.built_model is None:
             self._model.build(
                 experiment=self.experiment,
                 parameters=self.parameters,

--- a/pybop/problems/fitting_problem.py
+++ b/pybop/problems/fitting_problem.py
@@ -66,12 +66,12 @@ class FittingProblem(BaseProblem):
             self._model.n_time_data = self.n_time_data
 
             # Build the model from scratch
-            if self._model._built_model is not None:
-                self._model._model_with_set_params = None
-                self._model._built_model = None
-                self._model._built_initial_soc = None
-                self._model._mesh = None
-                self._model._disc = None
+            if self._model.built_model is not None:
+                self._model.model_with_set_params = None
+                self._model.built_model = None
+                self._model.built_initial_soc = None
+                self._model.mesh = None
+                self._model.disc = None
             self._model.build(
                 dataset=self._dataset,
                 parameters=self.parameters,

--- a/pybop/transformation/base_transformation.py
+++ b/pybop/transformation/base_transformation.py
@@ -105,7 +105,7 @@ class Transformation(ABC):
         """
         raise NotImplementedError("is_elementwise method must be implemented if used.")
 
-    def _verify_input(
+    def verify_input(
         self, inputs: Union[float, int, list[float], np.ndarray, dict[str, float]]
     ) -> np.ndarray:
         """Set and validate the transformation parameter."""

--- a/pybop/transformation/transformations.py
+++ b/pybop/transformation/transformations.py
@@ -90,9 +90,9 @@ class ScaledTransformation(Transformation):
         n_parameters: int = 1,
     ):
         self._n_parameters = n_parameters
-        self._intercept = self._verify_input(intercept)
-        self._coefficient = self._verify_input(coefficient)
-        self._inverse_coeff = np.reciprocal(self._coefficient)
+        self.intercept = self.verify_input(intercept)
+        self.coefficient = self.verify_input(coefficient)
+        self.inverse_coeff = np.reciprocal(self.coefficient)
 
     def is_elementwise(self) -> bool:
         """See :meth:`Transformation.is_elementwise()`."""
@@ -100,7 +100,7 @@ class ScaledTransformation(Transformation):
 
     def jacobian(self, q: np.ndarray) -> np.ndarray:
         """See :meth:`Transformation.jacobian()`."""
-        return np.diag(self._inverse_coeff)
+        return np.diag(self.inverse_coeff)
 
     def jacobian_S1(self, q: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         """See :meth:`Transformation.jacobian_S1()`."""
@@ -109,7 +109,7 @@ class ScaledTransformation(Transformation):
 
     def log_jacobian_det(self, q: np.ndarray) -> float:
         """See :meth:`Transformation.log_jacobian_det()`."""
-        return np.sum(np.log(np.abs(self._coefficient)))
+        return np.sum(np.log(np.abs(self.coefficient)))
 
     def log_jacobian_det_S1(self, q: np.ndarray) -> tuple[float, np.ndarray]:
         """See :meth:`Transformation.log_jacobian_det_S1()`."""
@@ -117,11 +117,11 @@ class ScaledTransformation(Transformation):
 
     def _transform(self, x: np.ndarray, method: str) -> np.ndarray:
         """See :meth:`Transformation._transform`."""
-        x = self._verify_input(x)
+        x = self.verify_input(x)
         if method == "to_model":
-            return x * self._inverse_coeff - self._intercept
+            return x * self.inverse_coeff - self.intercept
         elif method == "to_search":
-            return self._coefficient * (x + self._intercept)
+            return self.coefficient * (x + self.intercept)
         else:
             raise ValueError(f"Unknown method: {method}")
 
@@ -178,7 +178,7 @@ class LogTransformation(Transformation):
 
     def _transform(self, x: np.ndarray, method: str) -> np.ndarray:
         """See :meth:`Transformation._transform`."""
-        x = self._verify_input(x)
+        x = self.verify_input(x)
         if method == "to_model":
             return np.exp(x)
         elif method == "to_search":
@@ -260,7 +260,7 @@ class ComposedTransformation(Transformation):
         np.ndarray
             Diagonal matrix representing the elementwise Jacobian.
         """
-        q = self._verify_input(q)
+        q = self.verify_input(q)
         diag = np.zeros(self._n_parameters)
         lo = 0
 
@@ -273,7 +273,7 @@ class ComposedTransformation(Transformation):
 
     def jacobian_S1(self, q: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         """See :meth:`Transformation.jacobian_S1()`."""
-        q = self._verify_input(q)
+        q = self.verify_input(q)
         output_S1 = np.zeros(
             (self._n_parameters, self._n_parameters, self._n_parameters)
         )
@@ -302,7 +302,7 @@ class ComposedTransformation(Transformation):
         float
             Sum of log determinants of individual transformations.
         """
-        q = self._verify_input(q)
+        q = self.verify_input(q)
         return sum(
             transformation.log_jacobian_det(q[lo : lo + transformation.n_parameters])
             for lo, transformation in self._iter_transformations()
@@ -322,7 +322,7 @@ class ComposedTransformation(Transformation):
         Tuple[float, np.ndarray]
             Tuple of sum of log determinants and concatenated first-order sensitivities.
         """
-        q = self._verify_input(q)
+        q = self.verify_input(q)
         output = 0.0
         output_S1 = np.zeros(self._n_parameters)
         lo = 0
@@ -338,7 +338,7 @@ class ComposedTransformation(Transformation):
 
     def _transform(self, data: np.ndarray, method: str) -> np.ndarray:
         """See :meth:`Transformation._transform`."""
-        data = self._verify_input(data)
+        data = self.verify_input(data)
         output = np.zeros_like(data)
         lo = 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,10 +94,14 @@ select = [
     "ISC",  # flake8-implicit-str-concat: Check for implicit string concatenation
     "TID",  # flake8-tidy-imports: Validate import hygiene
     "UP",   # pyupgrade: Automatically upgrade syntax for newer versions of Python
+    "SLF001",  # flake8-string-format: Check for private object name access
 ]
 
 ignore = ["E501","E741"]
-per-file-ignores = {"**.ipynb" = ["E402", "E703"]}
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["SLF001"]
+"**.ipynb" = ["E402", "E703"]
 
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -92,7 +92,7 @@ class TestCosts:
             return cls(problem, p=2)
         elif cls in [pybop.ObserverCost]:
             inputs = problem.parameters.initial_value()
-            state = problem._model.reinit(inputs)
+            state = problem.model.reinit(inputs)
             n = len(state)
             sigma_diag = [0.0] * n
             sigma_diag[0] = 1e-4
@@ -106,7 +106,7 @@ class TestCosts:
             return cls(
                 pybop.UnscentedKalmanFilterObserver(
                     problem.parameters,
-                    problem._model,
+                    problem.model,
                     sigma0=sigma0,
                     process=process,
                     measure=1e-4,
@@ -221,7 +221,7 @@ class TestCosts:
                 assert "Non-physical point encountered" in str(record[i].message)
 
             # Test infeasible locations
-            cost.problem._model.allow_infeasible_solutions = False
+            cost.problem.model.allow_infeasible_solutions = False
             assert cost([1.1]) == np.inf
             assert cost.evaluateS1([1.1]) == (np.inf, cost._de)
             assert cost([0.01]) == np.inf
@@ -286,7 +286,7 @@ class TestCosts:
             assert cost([-0.1]) == -np.inf  # Should not be a viable design
 
             # Test infeasible locations
-            cost.problem._model.allow_infeasible_solutions = False
+            cost.problem.model.allow_infeasible_solutions = False
             assert cost([1.1]) == -np.inf
 
             # Test exception for non-numeric inputs

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -127,10 +127,10 @@ class TestCosts:
     @pytest.mark.unit
     def test_error_in_cost_calculation(self, problem):
         class RaiseErrorCost(pybop.BaseCost):
-            def _evaluate(self, inputs, grad=None):
+            def compute(self, inputs, grad=None):
                 raise ValueError("Error test.")
 
-            def _evaluateS1(self, inputs):
+            def computeS1(self, inputs):
                 raise ValueError("Error test.")
 
         cost = RaiseErrorCost(problem)

--- a/tests/unit/test_likelihoods.py
+++ b/tests/unit/test_likelihoods.py
@@ -77,7 +77,7 @@ class TestLikelihoods:
         assert likelihood.n_outputs == n_outputs
         assert likelihood.n_time_data == problem.n_time_data
         assert likelihood.n_parameters == 1
-        assert np.array_equal(likelihood._target, problem._target)
+        assert np.array_equal(likelihood.target, problem.target)
 
     @pytest.mark.unit
     def test_base_likelihood_call_raises_not_implemented_error(

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -183,18 +183,18 @@ class TestModels:
         # Test initilisation with different types of parameter set
         param_dict = {"Nominal cell capacity [A.h]": 5}
         model = pybop.BaseModel(parameter_set=None)
-        assert model._parameter_set is None
+        assert model.parameter_set is None
 
         model = pybop.BaseModel(parameter_set=param_dict)
         parameter_set = pybamm.ParameterValues(param_dict)
-        assert model._parameter_set == parameter_set
+        assert model.parameter_set == parameter_set
 
         model = pybop.BaseModel(parameter_set=parameter_set)
-        assert model._parameter_set == parameter_set
+        assert model.parameter_set == parameter_set
 
         pybop_parameter_set = pybop.ParameterSet(params_dict=param_dict)
         model = pybop.BaseModel(parameter_set=pybop_parameter_set)
-        assert model._parameter_set == parameter_set
+        assert model.parameter_set == parameter_set
 
     @pytest.mark.unit
     def test_rebuild_geometric_parameters(self):
@@ -232,8 +232,8 @@ class TestModels:
 
         # Test model geometry
         assert (
-            rebuilt_model._mesh["negative electrode"].nodes[1]
-            != initial_built_model._mesh["negative electrode"].nodes[1]
+            rebuilt_model.mesh["negative electrode"].nodes[1]
+            != initial_built_model.mesh["negative electrode"].nodes[1]
         )
         assert (
             rebuilt_model.geometry["negative electrode"]["x_n"]["max"]
@@ -246,8 +246,8 @@ class TestModels:
         )
 
         assert (
-            rebuilt_model._mesh["positive particle"].nodes[1]
-            != initial_built_model._mesh["positive particle"].nodes[1]
+            rebuilt_model.mesh["positive particle"].nodes[1]
+            != initial_built_model.mesh["positive particle"].nodes[1]
         )
 
         # Compare model results

--- a/tests/unit/test_optimisation.py
+++ b/tests/unit/test_optimisation.py
@@ -226,29 +226,29 @@ class TestOptimisation:
 
         # Test AdamW hyperparameters
         if optimiser in [pybop.AdamW]:
-            optim = optimiser(cost=cost, b1=0.9, b2=0.999, lambda_=0.1)
-            optim.pints_optimiser.set_b1(0.9)
-            optim.pints_optimiser.set_b2(0.9)
-            optim.pints_optimiser.set_lambda(0.1)
+            optim = optimiser(cost=cost, b1=0.9, b2=0.999, lam=0.1)
+            optim.pints_optimiser.b1 = 0.9
+            optim.pints_optimiser.b2 = 0.9
+            optim.pints_optimiser.lam = 0.1
 
-            assert optim.pints_optimiser._b1 == 0.9
-            assert optim.pints_optimiser._b2 == 0.9
-            assert optim.pints_optimiser._lambda == 0.1
+            assert optim.pints_optimiser.b1 == 0.9
+            assert optim.pints_optimiser.b2 == 0.9
+            assert optim.pints_optimiser.lam == 0.1
 
             # Incorrect values
             for i, _match in (("Value", -1),):
                 with pytest.raises(
                     Exception, match="must be a numeric value between 0 and 1."
                 ):
-                    optim.pints_optimiser.set_b1(i)
+                    optim.pints_optimiser.b1 = i
                 with pytest.raises(
                     Exception, match="must be a numeric value between 0 and 1."
                 ):
-                    optim.pints_optimiser.set_b2(i)
+                    optim.pints_optimiser.b2 = i
                 with pytest.raises(
                     Exception, match="must be a numeric value between 0 and 1."
                 ):
-                    optim.pints_optimiser.set_lambda(i)
+                    optim.pints_optimiser.lam = i
 
             # Check defaults
             assert optim.pints_optimiser.n_hyper_parameters() == 5

--- a/tests/unit/test_problem.py
+++ b/tests/unit/test_problem.py
@@ -71,7 +71,7 @@ class TestProblem:
         # Construct Problem
         problem = pybop.BaseProblem(parameters, model=model)
 
-        assert problem._model == model
+        assert problem.model == model
 
         with pytest.raises(NotImplementedError):
             problem.evaluate([1e-5, 1e-5])
@@ -112,8 +112,8 @@ class TestProblem:
         # Construct Problem
         problem = pybop.FittingProblem(model, parameters, dataset, signal=signal)
 
-        assert problem._model == model
-        assert problem._model._built_model is not None
+        assert problem.model == model
+        assert problem.model.built_model is not None
 
         # Test get target
         target = problem.get_target()["Voltage [V]"]
@@ -167,9 +167,9 @@ class TestProblem:
         # Construct Problem
         problem = pybop.DesignProblem(model, parameters, experiment)
 
-        assert problem._model == model
+        assert problem.model == model
         assert (
-            problem._model._built_model is None
+            problem.model.built_model is None
         )  # building postponed with input experiment
 
         # Test model.predict
@@ -191,7 +191,7 @@ class TestProblem:
         # Test problem evaluate
         problem_output = problem.evaluate([2e-5, 2e-5])
 
-        assert problem._model._built_model is not None
+        assert problem.model.built_model is not None
         with pytest.raises(AssertionError):
             assert_allclose(
                 out["Voltage [V]"].data,

--- a/tests/unit/test_transformations.py
+++ b/tests/unit/test_transformations.py
@@ -74,7 +74,7 @@ class TestTransformation:
         # Test covariance transformation
         cov = np.array([[0.5]])
         cov_transformed = transformation.convert_covariance_matrix(cov, q)
-        assert np.array_equal(cov_transformed, cov * transformation._coefficient**2)
+        assert np.array_equal(cov_transformed, cov * transformation.coefficient**2)
 
         # Test incorrect transform
         with pytest.raises(ValueError, match="Unknown method:"):
@@ -158,21 +158,21 @@ class TestTransformation:
             )
 
     @pytest.mark.unit
-    def test_verify_input(self, parameters):
+    def testverify_input(self, parameters):
         q = np.asarray([5.0])
         q_dict = {"Identity": q[0]}
         transformation = parameters["Scaled"].transformation
-        assert transformation._verify_input(q) == q
-        assert transformation._verify_input(q.tolist()) == q
-        assert transformation._verify_input(q_dict) == q
+        assert transformation.verify_input(q) == q
+        assert transformation.verify_input(q.tolist()) == q
+        assert transformation.verify_input(q_dict) == q
 
         with pytest.raises(
             TypeError, match="Transform must be a float, int, list, numpy array,"
         ):
-            transformation._verify_input("string")
+            transformation.verify_input("string")
 
         with pytest.raises(ValueError, match="Transform must have"):
-            transformation._verify_input(np.array([1.0, 2.0, 3.0]))
+            transformation.verify_input(np.array([1.0, 2.0, 3.0]))
 
 
 class TestBaseTransformation:


### PR DESCRIPTION
# Description

This PR adds the [SLF001](https://docs.astral.sh/ruff/rules/private-member-access/) rule to ruff linting, ensuring private members are not accessed outside the defining class. At the same time, this PR fixes our current access of private members which break SLF001. The main changes include:

- `cost._evaluate` and `cost._evaluateS1` are renamed to `cost.compute` and `cost.computeS1` to better align with their definition and improve clarity.
- Adds property functions for read-access on private objects, and setters if required.
- `AdamW.lambda` renamed to `AdamW.lam` to avoid namespace clash with python lambda.
- CONTRIBUTING.md has been updated for usage with SLF001

## Issue reference
Fixes #434

## Review
Before you mark your PR as ready for review, please ensure that you've considered the following:
- Updated the [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) in reverse chronological order (newest at the top) with a concise description of the changes, including the PR number.
- Noted any breaking changes, including details on how it might impact existing functionality.

## Type of change
- [ ] New Feature: A non-breaking change that adds new functionality.
- [ ] Optimization: A code change that improves performance.
- [ ] Examples: A change to existing or additional examples.
- [X] Bug Fix: A non-breaking change that addresses an issue.
- [ ] Documentation: Updates to documentation or new documentation for new features.
- [X] Refactoring: Non-functional changes that improve the codebase.
- [ ] Style: Non-functional changes related to code style (formatting, naming, etc).
- [ ] Testing: Additional tests to improve coverage or confirm functionality.
- [ ] Other: (Insert description of change)

# Key checklist:

- [X] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [X] All unit tests pass: `$ nox -s tests`
- [X] The documentation builds: `$ nox -s doctest`

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:
- [ ] Code is well-commented, especially in complex or unclear areas.
- [ ] Added tests that prove my fix is effective or that my feature works.
- [ ] Checked that coverage remains or improves, and added tests if necessary to maintain or increase coverage.

Thank you for contributing to our project! Your efforts help us to deliver great software.
