### PR TITLE
Add functional parameter example

### DIFF
--- a/examples/scripts/functional_parameters.py
+++ b/examples/scripts/functional_parameters.py
@@ -1,0 +1,90 @@
+import numpy as np
+import pybop
+import pybamm
+
+
+# This example demonstrates how to use a pybamm.FunctionalParameter to
+# optimise functional parameters using PyBOP.
+
+# Method: Define a new constant parameter for use in a functional parameter
+# that already exists in the model, for example an exchange current density.
+
+
+# Parameter set and model definition
+parameter_set = pybop.ParameterSet.pybamm("Chen2020")
+model = pybop.lithium_ion.SPM(parameter_set=parameter_set)
+
+# Define a new function using new parameters
+def positive_electrode_exchange_current_density(c_e, c_s_surf, c_s_max, T):
+    # New parameters
+    j0_ref = pybamm.Parameter(
+        "Positive electrode reference exchange-current density [A.m-2]"
+    )
+    alpha = pybamm.Parameter("Positive electrode charge transfer coefficient")
+
+    # Existing parameters
+    c_e_init = pybamm.Parameter("Initial concentration in electrolyte [mol.m-3]")
+
+    return (
+        j0_ref
+        * ((c_e / c_e_init) * (c_s_surf / c_s_max) * (1 - c_s_surf / c_s_max)) ** alpha
+    )
+
+
+# Give default values to the new constant parameters and pass the new function
+parameter_set.update(
+    {
+        "Positive electrode reference exchange-current density [A.m-2]": 1,
+        "Positive electrode charge transfer coefficient": 0.5,
+    },
+    check_already_exists=False,
+)
+parameter_set["Positive electrode exchange-current density [A.m-2]"] = positive_electrode_exchange_current_density
+
+# Fitting parameters
+parameters = pybop.Parameters(
+    pybop.Parameter(
+        "Positive electrode reference exchange-current density [A.m-2]",
+        prior=pybop.Gaussian(1, 0.1),
+    ),
+    pybop.Parameter(
+        "Positive electrode charge transfer coefficient",
+        prior=pybop.Gaussian(0.5, 0.1),
+    ),
+)
+
+# Generate data
+sigma = 0.001
+t_eval = np.arange(0, 900, 3)
+values = model.predict(t_eval=t_eval)
+corrupt_values = values["Voltage [V]"].data + np.random.normal(0, sigma, len(t_eval))
+
+# Form dataset
+dataset = pybop.Dataset(
+    {
+        "Time [s]": t_eval,
+        "Current function [A]": values["Current [A]"].data,
+        "Voltage [V]": corrupt_values,
+    }
+)
+
+# Generate problem, cost function, and optimisation class
+problem = pybop.FittingProblem(model, parameters, dataset)
+cost = pybop.RootMeanSquaredError(problem)
+optim = pybop.SciPyMinimize(cost,max_iterations=125)
+
+# Run optimisation
+x, final_cost = optim.run()
+print("Estimated parameters:", x)
+
+# Plot the timeseries output
+pybop.quick_plot(problem, problem_inputs=x, title="Optimised Comparison")
+
+# Plot convergence
+pybop.plot_convergence(optim)
+
+# Plot the parameter traces
+pybop.plot_parameters(optim)
+
+# Plot the cost landscape with optimisation path
+pybop.plot2d(optim, steps=15)


### PR DESCRIPTION
# Description

Adds an example demonstrating how a `pybamm.FunctionalParameter` may be employed in PyBOP.

## Issue reference
Fixes #441.

## Review
Before you mark your PR as ready for review, please ensure that you've considered the following:
- Updated the [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) in reverse chronological order (newest at the top) with a concise description of the changes, including the PR number.
- Noted any breaking changes, including details on how it might impact existing functionality.

## Type of change
- [ ] New Feature: A non-breaking change that adds new functionality.
- [ ] Optimization: A code change that improves performance.
- [ ] Examples: A change to existing or additional examples.
- [ ] Bug Fix: A non-breaking change that addresses an issue.
- [ ] Documentation: Updates to documentation or new documentation for new features.
- [ ] Refactoring: Non-functional changes that improve the codebase.
- [ ] Style: Non-functional changes related to code style (formatting, naming, etc).
- [ ] Testing: Additional tests to improve coverage or confirm functionality.
- [ ] Other: (Insert description of change)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All unit tests pass: `$ nox -s tests`
- [ ] The documentation builds: `$ nox -s doctest`

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:
- [ ] Code is well-commented, especially in complex or unclear areas.
- [ ] Added tests that prove my fix is effective or that my feature works.
- [ ] Checked that coverage remains or improves, and added tests if necessary to maintain or increase coverage.

Thank you for contributing to our project! Your efforts help us to deliver great software.
