### PR TITLE
Allow different lengths for validation plots

### DIFF
--- a/pybop/plot/problem.py
+++ b/pybop/plot/problem.py
@@ -73,8 +73,8 @@ def quick(problem, problem_inputs: Inputs = None, show=True, **layout_kwargs):
         )
         plot_dict.traces.append(target_trace)
 
-        if isinstance(problem, FittingProblem) and len(model_output) == len(
-            target_output
+        if isinstance(problem, FittingProblem) and len(model_output[i]) == len(
+            target_output[i]
         ):
             # Compute the standard deviation as proxy for uncertainty
             plot_dict.sigma = np.std(model_output[i] - target_output[i])

--- a/pybop/plot/problem.py
+++ b/pybop/plot/problem.py
@@ -73,7 +73,7 @@ def quick(problem, problem_inputs: Inputs = None, show=True, **layout_kwargs):
         )
         plot_dict.traces.append(target_trace)
 
-        if isinstance(problem, FittingProblem):
+        if isinstance(problem, FittingProblem) and len(model_output) == len(target_output):
             # Compute the standard deviation as proxy for uncertainty
             plot_dict.sigma = np.std(model_output[i] - target_output[i])
 

--- a/pybop/plot/problem.py
+++ b/pybop/plot/problem.py
@@ -73,7 +73,9 @@ def quick(problem, problem_inputs: Inputs = None, show=True, **layout_kwargs):
         )
         plot_dict.traces.append(target_trace)
 
-        if isinstance(problem, FittingProblem) and len(model_output) == len(target_output):
+        if isinstance(problem, FittingProblem) and len(model_output) == len(
+            target_output
+        ):
             # Compute the standard deviation as proxy for uncertainty
             plot_dict.sigma = np.std(model_output[i] - target_output[i])
 


### PR DESCRIPTION
# Description

The function `plot.quick` is useful for validation but fails to produce a figure when the target and model outputs have different lengths. This update disables the computation of the standard deviation which allows the target and model to be plotted regardless of length.

## Issue reference
Fixes # (issue-number)

## Review
Before you mark your PR as ready for review, please ensure that you've considered the following:
- Updated the [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) in reverse chronological order (newest at the top) with a concise description of the changes, including the PR number.
- Noted any breaking changes, including details on how it might impact existing functionality.

## Type of change
- [ ] New Feature: A non-breaking change that adds new functionality.
- [ ] Optimization: A code change that improves performance.
- [ ] Examples: A change to existing or additional examples.
- [ ] Bug Fix: A non-breaking change that addresses an issue.
- [ ] Documentation: Updates to documentation or new documentation for new features.
- [ ] Refactoring: Non-functional changes that improve the codebase.
- [ ] Style: Non-functional changes related to code style (formatting, naming, etc).
- [ ] Testing: Additional tests to improve coverage or confirm functionality.
- [ ] Other: (Insert description of change)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All unit tests pass: `$ nox -s tests`
- [ ] The documentation builds: `$ nox -s doctest`

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:
- [ ] Code is well-commented, especially in complex or unclear areas.
- [ ] Added tests that prove my fix is effective or that my feature works.
- [ ] Checked that coverage remains or improves, and added tests if necessary to maintain or increase coverage.

Thank you for contributing to our project! Your efforts help us to deliver great software.
