### PR TITLE
Default solver from Casadi to IDAKLU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Bug Fixes
 
 - [#705](https://github.com/pybop-team/PyBOP/pull/705) - Bug fix `fitting_problem.evaulate()` failure return type alongside fixes for Pybamm `v25.4`.
+- [#546](https://github.com/pybop-team/PyBOP/pull/546) - Default Pybamm solver to `IDAKLU`, changes required for Pybamm v25.4.1
 
 ## Breaking Changes
 

--- a/examples/notebooks/comparison_examples/comparing_cost_functions.ipynb
+++ b/examples/notebooks/comparison_examples/comparing_cost_functions.ipynb
@@ -32,7 +32,6 @@
     "%pip install pybop -q\n",
     "\n",
     "import numpy as np\n",
-    "import pybamm\n",
     "\n",
     "import pybop\n",
     "\n",
@@ -97,8 +96,7 @@
    "outputs": [],
    "source": [
     "parameter_set = pybop.ParameterSet(\"Chen2020\")\n",
-    "solver = pybamm.IDAKLUSolver()\n",
-    "model = pybop.lithium_ion.SPM(parameter_set=parameter_set, solver=solver)"
+    "model = pybop.lithium_ion.SPM(parameter_set=parameter_set)"
    ]
   },
   {

--- a/examples/scripts/battery_parameterisation/simple_pulse_fit.py
+++ b/examples/scripts/battery_parameterisation/simple_pulse_fit.py
@@ -1,7 +1,6 @@
 import os
 
 import numpy as np
-import pybamm
 
 import pybop
 
@@ -17,7 +16,7 @@ dataset_path = os.path.join(current_dir, "../../data/synthetic/spme_pulse_15.csv
 # Define model and use high-performant solver for sensitivities
 parameter_set = pybop.ParameterSet("Chen2020")
 model = pybop.lithium_ion.SPMe(
-    parameter_set=parameter_set, solver=pybamm.IDAKLUSolver(atol=1e-7, rtol=1e-7)
+    parameter_set=parameter_set,
 )
 
 # Fitting parameters

--- a/examples/scripts/comparison_examples/adamw.py
+++ b/examples/scripts/comparison_examples/adamw.py
@@ -1,7 +1,6 @@
 import os
 
 import numpy as np
-import pybamm
 
 import pybop
 
@@ -12,9 +11,8 @@ dataset_path = os.path.join(
 )
 
 # Define model and use high-performant solver for sensitivities
-solver = pybamm.IDAKLUSolver()
 parameter_set = pybop.ParameterSet("Chen2020")
-model = pybop.lithium_ion.SPM(parameter_set=parameter_set, solver=solver)
+model = pybop.lithium_ion.SPM(parameter_set=parameter_set)
 
 # Fitting parameters
 parameters = pybop.Parameters(

--- a/examples/scripts/comparison_examples/exponential_decay.py
+++ b/examples/scripts/comparison_examples/exponential_decay.py
@@ -4,11 +4,8 @@ import pybamm
 import pybop
 
 # Define model and use high-performant solver for sensitivities
-solver = pybamm.IDAKLUSolver
 parameter_set = pybamm.ParameterValues({"k": 1, "y0": 0.5})
-model = pybop.ExponentialDecayModel(
-    parameter_set=parameter_set, solver=solver, n_states=2
-)
+model = pybop.ExponentialDecayModel(parameter_set=parameter_set, n_states=2)
 
 # Fitting parameters
 parameters = pybop.Parameters(

--- a/examples/scripts/comparison_examples/gradient_descent.py
+++ b/examples/scripts/comparison_examples/gradient_descent.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pybamm
 
 import pybop
 
@@ -35,7 +34,6 @@ dataset = pybop.Dataset(
 )
 
 # Generate problem, cost function, and optimisation class
-model.solver = pybamm.IDAKLUSolver()
 problem = pybop.FittingProblem(model, parameters, dataset)
 cost = pybop.RootMeanSquaredError(problem)
 optim = pybop.GradientDescent(

--- a/examples/scripts/comparison_examples/maximum_likelihood.py
+++ b/examples/scripts/comparison_examples/maximum_likelihood.py
@@ -1,7 +1,6 @@
 import os
 
 import numpy as np
-import pybamm
 
 import pybop
 
@@ -19,8 +18,7 @@ parameter_set.update(
         "Positive electrode active material volume fraction": 0.51,
     }
 )
-solver = pybamm.IDAKLUSolver()
-model = pybop.lithium_ion.SPMe(parameter_set=parameter_set, solver=solver)
+model = pybop.lithium_ion.SPMe(parameter_set=parameter_set)
 
 # Fitting parameters
 parameters = pybop.Parameters(

--- a/examples/scripts/comparison_examples/scipy_minimize.py
+++ b/examples/scripts/comparison_examples/scipy_minimize.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pybamm
 
 import pybop
 
@@ -35,7 +34,6 @@ dataset = pybop.Dataset(
 )
 
 # Generate problem, cost function, and optimisation class
-model.solver = pybamm.IDAKLUSolver()
 problem = pybop.FittingProblem(model, parameters, dataset)
 cost = pybop.SumSquaredError(problem)
 optim = pybop.SciPyMinimize(

--- a/examples/scripts/comparison_examples/simulated_annealing.py
+++ b/examples/scripts/comparison_examples/simulated_annealing.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pybamm
 
 import pybop
 
@@ -37,7 +36,6 @@ dataset = pybop.Dataset(
 )
 
 # Generate problem, cost function, and optimisation class
-model.solver = pybamm.IDAKLUSolver()
 problem = pybop.FittingProblem(model, parameters, dataset)
 cost = pybop.RootMeanSquaredError(problem)
 optim = pybop.SimulatedAnnealing(

--- a/examples/scripts/comparison_examples/unscented_kalman_filter.py
+++ b/examples/scripts/comparison_examples/unscented_kalman_filter.py
@@ -1,10 +1,11 @@
 import numpy as np
+from pybamm import CasadiSolver
 
 import pybop
 
 # Parameter set and model definition
 parameter_set = pybop.ParameterSet("Chen2020")
-model = pybop.lithium_ion.SPM(parameter_set=parameter_set)
+model = pybop.lithium_ion.SPM(parameter_set=parameter_set, solver=CasadiSolver())
 
 # Fitting parameters
 parameters = pybop.Parameters(

--- a/examples/scripts/getting_started/ask-tell-interface.py
+++ b/examples/scripts/getting_started/ask-tell-interface.py
@@ -1,7 +1,6 @@
 import os
 
 import numpy as np
-import pybamm
 
 import pybop
 
@@ -11,10 +10,9 @@ dataset_path = os.path.join(
     current_dir, "../../data/synthetic/spm_charge_discharge_75.csv"
 )
 
-# Define model and use high-performant solver for sensitivities
-solver = pybamm.IDAKLUSolver()
+# Define model
 parameter_set = pybop.ParameterSet.pybamm("Chen2020")
-model = pybop.lithium_ion.SPM(parameter_set=parameter_set, solver=solver)
+model = pybop.lithium_ion.SPM(parameter_set=parameter_set)
 
 # Fitting parameters
 parameters = pybop.Parameters(

--- a/examples/scripts/getting_started/jax-solver-example.py
+++ b/examples/scripts/getting_started/jax-solver-example.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pybamm
 
 import pybop
 
@@ -8,8 +7,7 @@ parameter_set = pybop.ParameterSet("Chen2020")
 
 # The Jaxified IDAKLU performs very well on high iteration
 # identification tasks, due to the just-in-time compilation
-solver = pybamm.IDAKLUSolver()
-model = pybop.lithium_ion.SPMe(parameter_set=parameter_set, solver=solver)
+model = pybop.lithium_ion.SPMe(parameter_set=parameter_set)
 
 # Fitting parameters
 parameters = pybop.Parameters(

--- a/examples/scripts/getting_started/mcmc_example.py
+++ b/examples/scripts/getting_started/mcmc_example.py
@@ -1,7 +1,6 @@
 import sys
 
 import numpy as np
-import pybamm
 
 import pybop
 
@@ -9,7 +8,6 @@ import pybop
 parallel = True if sys.platform != "win32" else False
 
 # Parameter set and model definition
-solver = pybamm.IDAKLUSolver()
 parameter_set = pybop.ParameterSet("Chen2020")
 parameter_set.update(
     {
@@ -17,7 +15,7 @@ parameter_set.update(
         "Positive electrode active material volume fraction": 0.71,
     }
 )
-synth_model = pybop.lithium_ion.SPMe(parameter_set=parameter_set, solver=solver)
+synth_model = pybop.lithium_ion.SPMe(parameter_set=parameter_set)
 
 # Fitting parameters
 parameters = pybop.Parameters(
@@ -59,7 +57,7 @@ dataset = pybop.Dataset(
     }
 )
 
-model = pybop.lithium_ion.SPM(parameter_set=parameter_set, solver=pybamm.IDAKLUSolver())
+model = pybop.lithium_ion.SPM(parameter_set=parameter_set)
 signal = ["Voltage [V]"]
 
 # Generate problem, likelihood, and sampler

--- a/examples/scripts/getting_started/multi_start_optimisation.py
+++ b/examples/scripts/getting_started/multi_start_optimisation.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pybamm
 
 import pybop
 
@@ -35,7 +34,6 @@ dataset = pybop.Dataset(
 )
 
 # Generate problem, cost function classes
-model.solver = pybamm.IDAKLUSolver(atol=1e-5, rtol=1e-5)
 problem = pybop.FittingProblem(model, parameters, dataset)
 cost = pybop.RootMeanSquaredError(problem)
 

--- a/examples/scripts/getting_started/simple_dfn.py
+++ b/examples/scripts/getting_started/simple_dfn.py
@@ -1,7 +1,6 @@
 import os
 
 import numpy as np
-import pybamm
 
 import pybop
 
@@ -11,10 +10,9 @@ dataset_path = os.path.join(
     current_dir, "../../data/synthetic/dfn_charge_discharge_75.csv"
 )
 
-# Define model and use high-performant solver for sensitivities
-solver = pybamm.IDAKLUSolver()
+# Define model
 parameter_set = pybop.ParameterSet("Chen2020")
-model = pybop.lithium_ion.DFN(parameter_set=parameter_set, solver=solver)
+model = pybop.lithium_ion.DFN(parameter_set=parameter_set)
 
 # Fitting parameters
 parameters = pybop.Parameters(

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,7 @@ PYBAMM_VERSION = os.environ.get("PYBAMM_VERSION", None)
 
 @nox.session
 def unit(session):
-    session.install("-e", ".[all,dev]", silent=False)
+    session.install("-e", ".[all,dev]", "--upgrade", silent=False)
     if PYBOP_SCHEDULED:
         session.run("pip", "install", f"pybamm=={PYBAMM_VERSION}", silent=False)
     session.run("pytest", "--unit")
@@ -22,7 +22,7 @@ def unit(session):
 
 @nox.session
 def coverage(session):
-    session.install("-e", ".[all,dev]", silent=False)
+    session.install("-e", ".[all,dev]", "--upgrade", silent=False)
     session.install("pip")
     if PYBOP_SCHEDULED:
         session.run("pip", "install", f"pybamm=={PYBAMM_VERSION}", silent=False)
@@ -42,7 +42,7 @@ def coverage(session):
 @nox.session
 def plots(session):
     """Run the tests that generate plots."""
-    session.install("-e", ".[plot,dev]", silent=False)
+    session.install("-e", ".[plot,dev]", "--upgrade", silent=False)
     session.install("pip")
     session.run("pytest", "--plots", "-n", "0")
 
@@ -50,14 +50,14 @@ def plots(session):
 @nox.session
 def integration(session):
     """Run the integration tests."""
-    session.install("-e", ".[all,dev]", silent=False)
+    session.install("-e", ".[all,dev]", "--upgrade", silent=False)
     session.run("pytest", "--integration")
 
 
 @nox.session
 def examples(session):
     """Run the examples and notebooks"""
-    session.install("-e", ".[all,dev]", silent=False)
+    session.install("-e", ".[all,dev]", "--upgrade", silent=False)
     session.run("pytest", "--examples")
     notebooks(session)
 
@@ -66,7 +66,7 @@ def examples(session):
 def notebooks(session):
     """Run the Jupyter notebooks."""
     session.install("openpyxl", "ipywidgets")
-    session.install("-e", ".[all,dev]", silent=False)
+    session.install("-e", ".[all,dev]", "--upgrade", silent=False)
     if PYBOP_SCHEDULED:
         session.run("pip", "install", f"pybamm=={PYBAMM_VERSION}", silent=False)
     session.run(
@@ -82,7 +82,7 @@ def notebooks(session):
 def notebooks_overwrite(session):
     """Run the Jupyter notebooks."""
     session.install("openpyxl", "ipywidgets")
-    session.install("-e", ".[all,dev]", silent=False)
+    session.install("-e", ".[all,dev]", "--upgrade", silent=False)
     if PYBOP_SCHEDULED:
         session.run("pip", "install", f"pybamm=={PYBAMM_VERSION}", silent=False)
     session.run(
@@ -98,7 +98,7 @@ def notebooks_overwrite(session):
 @nox.session(name="tests")
 def run_tests(session):
     """Run all or a user-defined set of tests."""
-    session.install("-e", ".[all,dev]", silent=False)
+    session.install("-e", ".[all,dev]", "--upgrade", silent=False)
     if PYBOP_SCHEDULED:
         session.run("pip", "install", f"pybamm=={PYBAMM_VERSION}", silent=False)
     specific_tests = session.posargs if session.posargs else []
@@ -120,7 +120,7 @@ def run_doc_tests(session):
     Checks if the documentation can be built, runs any doctests (currently not
     used).
     """
-    session.install("-e", ".[plot,docs,dev]", silent=False)
+    session.install("-e", ".[plot,docs,dev]", "--upgrade", silent=False)
     session.run("pytest", "--docs", "-n", "0")
 
 
@@ -149,7 +149,7 @@ def run_quick(session):
 @nox.session
 def benchmarks(session):
     """Run the benchmarks."""
-    session.install("-e", ".[all,dev]", silent=False)
+    session.install("-e", ".[all,dev]", "--upgrade", silent=False)
     session.install("asv[virtualenv]")
     session.run("asv", "run", "--show-stderr", "--python=same")
 
@@ -161,7 +161,7 @@ def docs(session):
     Credit: PyBaMM Team
     """
     envbindir = session.bin
-    session.install("-e", ".[all,docs]", silent=False)
+    session.install("-e", ".[all,docs]", "--upgrade", silent=False)
     session.chdir("docs")
     # Local development
     if session.interactive:

--- a/noxfile.py
+++ b/noxfile.py
@@ -135,7 +135,7 @@ def lint(session):
     session.run("pre-commit", "run", "--all-files")
 
 
-@nox.session(name="quick", reuse_venv=True)
+@nox.session(name="quick")
 def run_quick(session):
     """
     Run integration tests, unit tests, and doctests sequentially

--- a/pybop/models/base_model.py
+++ b/pybop/models/base_model.py
@@ -295,6 +295,14 @@ class BaseModel:
         model : pybamm.Model
             The PyBaMM model to be used for EIS simulations.
         """
+        if not isinstance(self._solver, pybamm.CasadiSolver):
+            print(
+                "CasadiSolver is required for EIS predictions, the solver has been changed."
+            )
+            self._solver = pybamm.CasadiSolver(
+                atol=self._solver.atol, rtol=self._solver.rtol
+            )
+
         V_cell = pybamm.Variable("Voltage variable [V]")
         model.variables["Voltage variable [V]"] = V_cell
         V = model.variables["Voltage [V]"]

--- a/pybop/models/lithium_ion/base_echem.py
+++ b/pybop/models/lithium_ion/base_echem.py
@@ -76,8 +76,6 @@ class EChemBaseModel(BaseModel):
         )
         if solver is None:
             self._solver = self.pybamm_model.default_solver
-            self._solver.mode = "fast with events"
-            self._solver.max_step_decrease_count = 1
         else:
             self._solver = solver
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">=3.9, <3.13"
 dependencies = [
-    "pybamm[jax]>=24.9",
+    "pybamm[jax]>=24.5.1",
     "numpy>=1.16, <2.0",
     "scipy>=1.3",
     "pints>=0.5",

--- a/tests/integration/test_jax_parameterisations.py
+++ b/tests/integration/test_jax_parameterisations.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-from pybamm import IDAKLUSolver
 
 import pybop
 
@@ -94,7 +93,6 @@ class Test_Jax_Parameterisation:
         )
 
         # Define the problem
-        model.solver = IDAKLUSolver()
         problem = pybop.FittingProblem(model, parameters, dataset)
 
         # Construct the cost

--- a/tests/integration/test_model_experiment_changes.py
+++ b/tests/integration/test_model_experiment_changes.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pybamm
 import pytest
 
 import pybop
@@ -36,13 +37,18 @@ class TestModelAndExperimentChanges:
     def parameters(self, request):
         return request.param
 
-    def test_changing_experiment(self, parameters):
+    @pytest.fixture
+    def solver(self):
+        return pybamm.IDAKLUSolver(atol=1e-6, rtol=1e-6)
+
+    @pytest.mark.integration
+    def test_changing_experiment(self, parameters, solver):
         # Change the experiment and check that the results are different.
 
         parameter_set = pybop.ParameterSet("Chen2020")
         parameter_set.update(parameters.as_dict("true"))
         initial_state = {"Initial SoC": 0.5}
-        model = pybop.lithium_ion.SPM(parameter_set=parameter_set)
+        model = pybop.lithium_ion.SPM(parameter_set=parameter_set, solver=solver)
 
         t_eval = np.arange(0, 3600, 2)  # Default 1C discharge to cut-off voltage
         solution_1 = model.predict(initial_state=initial_state, t_eval=t_eval)
@@ -66,7 +72,7 @@ class TestModelAndExperimentChanges:
         np.testing.assert_allclose(cost_1, 0, atol=1e-5)
         np.testing.assert_allclose(cost_2, 0, atol=1e-5)
 
-    def test_changing_model(self, parameters):
+    def test_changing_model(self, parameters, solver):
         # Change the model and check that the results are different.
 
         parameter_set = pybop.ParameterSet("Chen2020")
@@ -74,11 +80,11 @@ class TestModelAndExperimentChanges:
         initial_state = {"Initial SoC": 0.5}
         experiment = pybop.Experiment(["Charge at 1C until 4.1 V (30 seconds period)"])
 
-        model = pybop.lithium_ion.SPM(parameter_set=parameter_set)
+        model = pybop.lithium_ion.SPM(parameter_set=parameter_set, solver=solver)
         solution_1 = model.predict(initial_state=initial_state, experiment=experiment)
         cost_1 = self.final_cost(solution_1, model, parameters)
 
-        model = pybop.lithium_ion.SPMe(parameter_set=parameter_set)
+        model = pybop.lithium_ion.SPMe(parameter_set=parameter_set, solver=solver)
         solution_2 = model.predict(initial_state=initial_state, experiment=experiment)
         cost_2 = self.final_cost(solution_2, model, parameters)
 
@@ -108,7 +114,7 @@ class TestModelAndExperimentChanges:
         results = optim.run()
         return results.final_cost
 
-    def test_multi_fitting_problem(self):
+    def test_multi_fitting_problem(self, solver):
         parameter_set = pybop.ParameterSet("Chen2020")
         parameters = pybop.Parameters(
             pybop.Parameter(
@@ -120,7 +126,7 @@ class TestModelAndExperimentChanges:
             )
         )
 
-        model_1 = pybop.lithium_ion.SPM(parameter_set=parameter_set)
+        model_1 = pybop.lithium_ion.SPM(parameter_set=parameter_set, solver=solver)
         experiment_1 = pybop.Experiment(
             ["Discharge at 0.5C for 5 minutes (10 seconds period)"]
         )
@@ -133,7 +139,9 @@ class TestModelAndExperimentChanges:
             }
         )
 
-        model_2 = pybop.lithium_ion.SPMe(parameter_set=parameter_set.copy())
+        model_2 = pybop.lithium_ion.SPMe(
+            parameter_set=parameter_set.copy(), solver=solver
+        )
         experiment_2 = pybop.Experiment(
             ["Discharge at 1C for 3 minutes (10 seconds period)"]
         )

--- a/tests/integration/test_monte_carlo.py
+++ b/tests/integration/test_monte_carlo.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-from pybamm import IDAKLUSolver
 
 import pybop
 from pybop import (
@@ -78,7 +77,6 @@ class Test_Sampling_SPM:
         )
 
         # Define the posterior to optimise
-        model.solver = IDAKLUSolver()
         problem = pybop.FittingProblem(model, parameters, dataset)
         likelihood = pybop.GaussianLogLikelihood(problem, sigma0=0.002 * 1.2)
         return pybop.LogPosterior(likelihood)

--- a/tests/integration/test_monte_carlo_thevenin.py
+++ b/tests/integration/test_monte_carlo_thevenin.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pybamm
 import pytest
 
 import pybop
@@ -52,8 +51,7 @@ class TestSamplingThevenin:
                 "R1 [Ohm]": self.ground_truth[1],
             }
         )
-        solver = pybamm.IDAKLUSolver()
-        return pybop.empirical.Thevenin(parameter_set=parameter_set, solver=solver)
+        return pybop.empirical.Thevenin(parameter_set=parameter_set)
 
     @pytest.fixture
     def parameters(self):

--- a/tests/integration/test_observer_parameterisation.py
+++ b/tests/integration/test_observer_parameterisation.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-from pybamm import IDAKLUSolver
 
 import pybop
 
@@ -28,9 +27,7 @@ class TestObservers:
 
     @pytest.fixture
     def model(self, parameter_set):
-        return pybop.ExponentialDecayModel(
-            parameter_set=parameter_set, solver=IDAKLUSolver, n_states=1
-        )
+        return pybop.ExponentialDecayModel(parameter_set=parameter_set, n_states=1)
 
     @pytest.fixture
     def parameters(self, parameter_set):

--- a/tests/integration/test_spm_parameterisations.py
+++ b/tests/integration/test_spm_parameterisations.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pybamm
 import pytest
 
 import pybop
@@ -31,8 +30,7 @@ class Test_SPM_Parameterisation:
                 "Positive electrode active material volume fraction": x[1],
             }
         )
-        solver = pybamm.IDAKLUSolver()
-        return pybop.lithium_ion.SPM(parameter_set=parameter_set, solver=solver)
+        return pybop.lithium_ion.SPM(parameter_set=parameter_set)
 
     @pytest.fixture
     def parameters(self):

--- a/tests/integration/test_thevenin_parameterisation.py
+++ b/tests/integration/test_thevenin_parameterisation.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-from pybamm import IDAKLUSolver
 
 import pybop
 
@@ -32,8 +31,7 @@ class TestTheveninParameterisation:
                 "R1 [Ohm]": self.ground_truth[1],
             }
         )
-        solver = IDAKLUSolver()
-        return pybop.empirical.Thevenin(parameter_set=parameter_set, solver=solver)
+        return pybop.empirical.Thevenin(parameter_set=parameter_set)
 
     @pytest.fixture
     def parameters(self):

--- a/tests/integration/test_transformation.py
+++ b/tests/integration/test_transformation.py
@@ -1,7 +1,6 @@
 import itertools
 
 import numpy as np
-import pybamm
 import pytest
 
 import pybop
@@ -47,8 +46,7 @@ class TestTransformation:
                 "R1 [Ohm]": self.ground_truth[1],
             }
         )
-        solver = pybamm.IDAKLUSolver()
-        return pybop.empirical.Thevenin(parameter_set=parameter_set, solver=solver)
+        return pybop.empirical.Thevenin(parameter_set=parameter_set)
 
     @pytest.fixture
     def parameters(self, transformation_r0, transformation_r1):

--- a/tests/unit/experimental/test_jax_costs.py
+++ b/tests/unit/experimental/test_jax_costs.py
@@ -17,8 +17,7 @@ class TestJaxCosts:
 
     @pytest.fixture
     def model(self, ground_truth):
-        solver = pybamm.IDAKLUSolver()
-        model = pybop.lithium_ion.SPM(solver=solver)
+        model = pybop.lithium_ion.SPM()
         model.parameter_set["Negative electrode active material volume fraction"] = (
             ground_truth
         )

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -16,8 +16,7 @@ class TestCosts:
 
     @pytest.fixture
     def model(self, ground_truth):
-        solver = pybamm.IDAKLUSolver()
-        model = pybop.lithium_ion.SPM(solver=solver)
+        model = pybop.lithium_ion.SPM()
         model.parameter_set["Negative electrode active material volume fraction"] = (
             ground_truth
         )

--- a/tests/unit/test_cost_interface.py
+++ b/tests/unit/test_cost_interface.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pybamm
 import pytest
 
 import pybop
@@ -18,7 +19,8 @@ class TestCostInterface:
 
     @pytest.fixture
     def model(self):
-        return pybop.lithium_ion.SPM()
+        solver = pybamm.IDAKLUSolver(atol=5e-6, rtol=5e-6)
+        return pybop.lithium_ion.SPM(solver=solver)
 
     @pytest.fixture
     def parameters(self):

--- a/tests/unit/test_likelihoods.py
+++ b/tests/unit/test_likelihoods.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pybamm
 import pytest
 
 import pybop
@@ -14,8 +13,7 @@ class TestLikelihoods:
 
     @pytest.fixture
     def model(self, ground_truth):
-        solver = pybamm.IDAKLUSolver()
-        model = pybop.lithium_ion.SPM(solver=solver)
+        model = pybop.lithium_ion.SPM()
         model.parameter_set.update(
             {
                 "Negative electrode active material volume fraction": ground_truth,

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -442,36 +442,6 @@ class TestModels:
             ):
                 model.check_params(inputs=["unexpected_string"])
 
-    def test_non_converged_solution(self):
-        model = pybop.lithium_ion.DFN()
-        parameters = pybop.Parameters(
-            pybop.Parameter(
-                "Negative electrode active material volume fraction",
-                prior=pybop.Gaussian(0.2, 0.01),
-            ),
-            pybop.Parameter(
-                "Positive electrode active material volume fraction",
-                prior=pybop.Gaussian(0.2, 0.01),
-            ),
-        )
-        dataset = pybop.Dataset(
-            {
-                "Time [s]": np.linspace(0, 100, 100),
-                "Current function [A]": np.zeros(100),
-                "Voltage [V]": np.zeros(100),
-            }
-        )
-        problem = pybop.FittingProblem(model, parameters=parameters, dataset=dataset)
-
-        # Simulate the DFN with active material values of 0.
-        # The solution elements will not change as the solver will not converge.
-        output = problem.evaluate([0, 0])
-        output_S1, _ = problem.evaluateS1([0, 0])
-
-        for key in problem.signal:
-            assert np.allclose(output.get(key, [])[0], output.get(key, []))
-            assert np.allclose(output_S1.get(key, [])[0], output_S1.get(key, []))
-
     def test_set_initial_state(self):
         t_eval = np.linspace(0, 10, 100)
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -311,7 +311,10 @@ class TestModels:
     def test_simulate(self, model_cls):
         k = 0.1
         y0 = 1
-        model = model_cls(pybamm.ParameterValues({"k": k, "y0": y0}))
+        args = {"parameter_set": pybamm.ParameterValues({"k": k, "y0": y0})}
+        if model_cls == pybop.ExponentialDecayModel:
+            args["solver"] = pybamm.CasadiSolver()
+        model = model_cls(**args)
         model.build()
         model.signal = ["y_0"]
         inputs = {}

--- a/tests/unit/test_plots.py
+++ b/tests/unit/test_plots.py
@@ -1,7 +1,6 @@
 import warnings
 
 import numpy as np
-import pybamm
 import pytest
 from packaging import version
 
@@ -83,7 +82,6 @@ class TestPlots:
 
     @pytest.fixture
     def jax_fitting_problem(self, model, parameters, dataset):
-        model.solver = pybamm.IDAKLUSolver()
         problem = pybop.FittingProblem(model, parameters, dataset)
         problem.model.jaxify_solver(t_eval=problem.domain_data)
         return problem


### PR DESCRIPTION
# Description

This PR adds the required changes for PyBaMM's switch to the IDAKLU solver as default.

This relates to PyBAMM's [#4545](https://github.com/pybamm-team/PyBaMM/issues/4545), where the CasadiSolver's explicit sensitivity functional is planned to be depreciated.

## Issue reference
Fixes # (issue-number)

## Review
Before you mark your PR as ready for review, please ensure that you've considered the following:
- Updated the [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) in reverse chronological order (newest at the top) with a concise description of the changes, including the PR number.
- Noted any breaking changes, including details on how it might impact existing functionality.

## Type of change
- [ ] New Feature: A non-breaking change that adds new functionality.
- [ ] Optimization: A code change that improves performance.
- [ ] Examples: A change to existing or additional examples.
- [ ] Bug Fix: A non-breaking change that addresses an issue.
- [ ] Documentation: Updates to documentation or new documentation for new features.
- [ ] Refactoring: Non-functional changes that improve the codebase.
- [ ] Style: Non-functional changes related to code style (formatting, naming, etc).
- [ ] Testing: Additional tests to improve coverage or confirm functionality.
- [ ] Other: (Insert description of change)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All unit tests pass: `$ nox -s tests`
- [ ] The documentation builds: `$ nox -s doctest`

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:
- [ ] Code is well-commented, especially in complex or unclear areas.
- [ ] Added tests that prove my fix is effective or that my feature works.
- [ ] Checked that coverage remains or improves, and added tests if necessary to maintain or increase coverage.

Thank you for contributing to our project! Your efforts help us to deliver great software.
