### PR TITLE
Multi-start functionality for optimisers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- [#570](https://github.com/pybop-team/PyBOP/pull/570) - Adds Multistart functionality to optimisers via initialisation arg `multistart`
 - [#569](https://github.com/pybop-team/PyBOP/pull/569) - Adds parameter specific learning rate functionality to GradientDescent optimiser.
 - [#282](https://github.com/pybop-team/PyBOP/issues/282) - Restructures the examples directory.
 - [#396](https://github.com/pybop-team/PyBOP/issues/396) - Adds `ecm_with_tau.py` example script.

--- a/examples/scripts/comparison_examples/spm_descent.py
+++ b/examples/scripts/comparison_examples/spm_descent.py
@@ -12,11 +12,11 @@ model = pybop.lithium_ion.SPM(parameter_set=parameter_set, solver=solver)
 parameters = pybop.Parameters(
     pybop.Parameter(
         "Negative electrode active material volume fraction",
-        prior=pybop.Gaussian(0.6, 0.01),
+        prior=pybop.Gaussian(0.6, 0.1),
     ),
     pybop.Parameter(
         "Positive electrode active material volume fraction",
-        prior=pybop.Gaussian(0.6, 0.01),
+        prior=pybop.Gaussian(0.6, 0.1),
     ),
 )
 
@@ -39,10 +39,7 @@ dataset = pybop.Dataset(
 problem = pybop.FittingProblem(model, parameters, dataset)
 cost = pybop.RootMeanSquaredError(problem)
 optim = pybop.GradientDescent(
-    cost,
-    sigma0=[0.6, 0.02],
-    verbose=True,
-    max_iterations=75,
+    cost, sigma0=[0.6, 0.02], verbose=True, max_iterations=75, multistart=5
 )
 
 # Run optimisation

--- a/pybop/optimisers/base_optimiser.py
+++ b/pybop/optimisers/base_optimiser.py
@@ -115,6 +115,7 @@ class BaseOptimiser:
             raise ValueError("There are no parameters to optimise.")
 
         self.unset_options = optimiser_kwargs
+        self.unset_options_store = optimiser_kwargs.copy()
         self.set_base_options()
         self._set_up_optimiser()
 
@@ -179,6 +180,7 @@ class BaseOptimiser:
         """
         for i in range(self.multistart):
             if i >= 1:
+                self.unset_options = self.unset_options_store.copy()
                 self.x0 = self.parameters.rvs(1, apply_transform=True)
                 self.parameters.update(initial_values=self.x0)
                 self._set_up_optimiser()

--- a/pybop/optimisers/base_optimiser.py
+++ b/pybop/optimisers/base_optimiser.py
@@ -152,6 +152,9 @@ class BaseOptimiser:
                 self.unset_options.pop("allow_infeasible_solutions")
             )
 
+        # Set multistart
+        self.multistart = self.unset_options.pop("multistart", 1)
+
     def _set_up_optimiser(self):
         """
         Parse optimiser options and prepare the optimiser.
@@ -174,13 +177,19 @@ class BaseOptimiser:
         results: OptimisationResult
             The pybop optimisation result class.
         """
-        self.result = self._run()
+        for i in range(self.multistart):
+            if i >= 1:
+                self.x0 = self.parameters.rvs(1, apply_transform=True)
+                self.parameters.update(initial_values=self.x0)
+                self._set_up_optimiser()
 
-        if self.verbose:
-            print(self.result)
+            self.result = self._run()
 
-        # Store the optimised parameters
-        self.parameters.update(values=self.result.x)
+            if self.verbose:
+                print(self.result)
+
+            # Store the optimised parameters
+            self.parameters.update(values=self.result.x)
 
         return self.result
 

--- a/pybop/optimisers/base_pints_optimiser.py
+++ b/pybop/optimisers/base_pints_optimiser.py
@@ -60,6 +60,7 @@ class BasePintsOptimiser(BaseOptimiser):
         max_iterations: int = None,
         min_iterations: int = 2,
         max_unchanged_iterations: int = 15,
+        multistart: int = 1,
         parallel: bool = False,
         **optimiser_kwargs,
     ):
@@ -85,7 +86,8 @@ class BasePintsOptimiser(BaseOptimiser):
             "threshold": self.set_threshold,
         }
 
-        self.optimiser = pints_optimiser
+        self._pints_optimiser = pints_optimiser
+        optimiser_kwargs["multistart"] = multistart
         super().__init__(cost, **optimiser_kwargs)
 
     def _set_up_optimiser(self):
@@ -96,8 +98,8 @@ class BasePintsOptimiser(BaseOptimiser):
         self._sanitise_inputs()
 
         # Create an instance of the PINTS optimiser class
-        if issubclass(self.optimiser, PintsOptimiser):
-            self.optimiser = self.optimiser(
+        if issubclass(self._pints_optimiser, PintsOptimiser):
+            self.optimiser = self._pints_optimiser(
                 self.x0, sigma0=self.sigma0, boundaries=self._boundaries
             )
         else:
@@ -136,18 +138,18 @@ class BasePintsOptimiser(BaseOptimiser):
         # Convert bounds to PINTS boundaries
         if self.bounds is not None:
             ignored_optimisers = (GradientDescentImpl, PintsAdam, PintsNelderMead)
-            if issubclass(self.optimiser, ignored_optimisers):
-                print(f"NOTE: Boundaries ignored by {self.optimiser}")
+            if issubclass(self._pints_optimiser, ignored_optimisers):
+                print(f"NOTE: Boundaries ignored by {self._pints_optimiser}")
                 self.bounds = None
             else:
-                if issubclass(self.optimiser, PintsPSO):
+                if issubclass(self._pints_optimiser, PintsPSO):
                     if not all(
                         np.isfinite(value)
                         for sublist in self.bounds.values()
                         for value in sublist
                     ):
                         raise ValueError(
-                            f"Either all bounds or no bounds must be set for {self.optimiser.__name__}."
+                            f"Either all bounds or no bounds must be set for {self._pints_optimiser.__name__}."
                         )
                 self._boundaries = PintsRectangularBoundaries(
                     self.bounds["lower"], self.bounds["upper"]

--- a/pybop/optimisers/pints_optimisers.py
+++ b/pybop/optimisers/pints_optimisers.py
@@ -35,6 +35,9 @@ class GradientDescent(BasePintsOptimiser):
         Minimum number of iterations before termination.
     max_unchanged_iterations : int, optional (default=15)
         Maximum number of iterations without improvement before termination.
+    multistart : int, optional (default=1)
+        Number of optimiser restarts from randomly sample position. These positions
+        are sampled from the priors.
     parallel : bool, optional (default=False)
         Whether to run the optimisation in parallel.
     **optimiser_kwargs : optional
@@ -68,6 +71,7 @@ class GradientDescent(BasePintsOptimiser):
         max_iterations: int = None,
         min_iterations: int = 2,
         max_unchanged_iterations: int = 15,
+        multistart: int = 1,
         parallel: bool = False,
         **optimiser_kwargs,
     ):
@@ -77,6 +81,7 @@ class GradientDescent(BasePintsOptimiser):
             max_iterations,
             min_iterations,
             max_unchanged_iterations,
+            multistart,
             parallel,
             **optimiser_kwargs,
         )
@@ -101,6 +106,9 @@ class Adam(BasePintsOptimiser):
         Minimum number of iterations before termination.
     max_unchanged_iterations : int, optional (default=15)
         Maximum number of iterations without improvement before termination.
+    multistart : int, optional (default=1)
+        Number of optimiser restarts from randomly sample position. These positions
+        are sampled from the priors.
     parallel : bool, optional (default=False)
         Whether to run the optimisation in parallel.
     **optimiser_kwargs : optional
@@ -140,6 +148,7 @@ class Adam(BasePintsOptimiser):
         max_iterations: int = None,
         min_iterations: int = 2,
         max_unchanged_iterations: int = 15,
+        multistart: int = 1,
         parallel: bool = False,
         **optimiser_kwargs,
     ):
@@ -149,6 +158,7 @@ class Adam(BasePintsOptimiser):
             max_iterations,
             min_iterations,
             max_unchanged_iterations,
+            multistart,
             parallel,
             **optimiser_kwargs,
         )
@@ -175,6 +185,9 @@ class AdamW(BasePintsOptimiser):
         Minimum number of iterations before termination.
     max_unchanged_iterations : int, optional (default=15)
         Maximum number of iterations without improvement before termination.
+    multistart : int, optional (default=1)
+        Number of optimiser restarts from randomly sample position. These positions
+        are sampled from the priors.
     parallel : bool, optional (default=False)
         Whether to run the optimisation in parallel.
     **optimiser_kwargs : optional
@@ -208,6 +221,7 @@ class AdamW(BasePintsOptimiser):
         max_iterations: int = None,
         min_iterations: int = 2,
         max_unchanged_iterations: int = 15,
+        multistart: int = 1,
         parallel: bool = False,
         **optimiser_kwargs,
     ):
@@ -217,6 +231,7 @@ class AdamW(BasePintsOptimiser):
             max_iterations,
             min_iterations,
             max_unchanged_iterations,
+            multistart,
             parallel,
             **optimiser_kwargs,
         )
@@ -240,6 +255,9 @@ class IRPropMin(BasePintsOptimiser):
         Minimum number of iterations before termination.
     max_unchanged_iterations : int, optional (default=15)
         Maximum number of iterations without improvement before termination.
+    multistart : int, optional (default=1)
+        Number of optimiser restarts from randomly sample position. These positions
+        are sampled from the priors.
     parallel : bool, optional (default=False)
         Whether to run the optimisation in parallel.
     **optimiser_kwargs : optional
@@ -273,6 +291,7 @@ class IRPropMin(BasePintsOptimiser):
         max_iterations: int = None,
         min_iterations: int = 2,
         max_unchanged_iterations: int = 15,
+        multistart: int = 1,
         parallel: bool = False,
         **optimiser_kwargs,
     ):
@@ -282,6 +301,7 @@ class IRPropMin(BasePintsOptimiser):
             max_iterations,
             min_iterations,
             max_unchanged_iterations,
+            multistart,
             parallel,
             **optimiser_kwargs,
         )
@@ -305,6 +325,9 @@ class PSO(BasePintsOptimiser):
         Minimum number of iterations before termination.
     max_unchanged_iterations : int, optional (default=15)
         Maximum number of iterations without improvement before termination.
+    multistart : int, optional (default=1)
+        Number of optimiser restarts from randomly sample position. These positions
+        are sampled from the priors.
     parallel : bool, optional (default=False)
         Whether to run the optimisation in parallel.
     **optimiser_kwargs : optional
@@ -338,6 +361,7 @@ class PSO(BasePintsOptimiser):
         max_iterations: int = None,
         min_iterations: int = 2,
         max_unchanged_iterations: int = 15,
+        multistart: int = 1,
         parallel: bool = False,
         **optimiser_kwargs,
     ):
@@ -347,6 +371,7 @@ class PSO(BasePintsOptimiser):
             max_iterations,
             min_iterations,
             max_unchanged_iterations,
+            multistart,
             parallel,
             **optimiser_kwargs,
         )
@@ -370,6 +395,9 @@ class SNES(BasePintsOptimiser):
         Minimum number of iterations before termination.
     max_unchanged_iterations : int, optional (default=15)
         Maximum number of iterations without improvement before termination.
+    multistart : int, optional (default=1)
+        Number of optimiser restarts from randomly sample position. These positions
+        are sampled from the priors.
     parallel : bool, optional (default=False)
         Whether to run the optimisation in parallel.
     **optimiser_kwargs : optional
@@ -403,6 +431,7 @@ class SNES(BasePintsOptimiser):
         max_iterations: int = None,
         min_iterations: int = 2,
         max_unchanged_iterations: int = 15,
+        multistart: int = 1,
         parallel: bool = False,
         **optimiser_kwargs,
     ):
@@ -412,6 +441,7 @@ class SNES(BasePintsOptimiser):
             max_iterations,
             min_iterations,
             max_unchanged_iterations,
+            multistart,
             parallel,
             **optimiser_kwargs,
         )
@@ -435,6 +465,9 @@ class XNES(BasePintsOptimiser):
         Minimum number of iterations before termination.
     max_unchanged_iterations : int, optional (default=15)
         Maximum number of iterations without improvement before termination.
+    multistart : int, optional (default=1)
+        Number of optimiser restarts from randomly sample position. These positions
+        are sampled from the priors.
     parallel : bool, optional (default=False)
         Whether to run the optimisation in parallel.
     **optimiser_kwargs : optional
@@ -468,6 +501,7 @@ class XNES(BasePintsOptimiser):
         max_iterations: int = None,
         min_iterations: int = 2,
         max_unchanged_iterations: int = 15,
+        multistart: int = 1,
         parallel: bool = False,
         **optimiser_kwargs,
     ):
@@ -477,6 +511,7 @@ class XNES(BasePintsOptimiser):
             max_iterations,
             min_iterations,
             max_unchanged_iterations,
+            multistart,
             parallel,
             **optimiser_kwargs,
         )
@@ -502,6 +537,9 @@ class NelderMead(BasePintsOptimiser):
         Minimum number of iterations before termination.
     max_unchanged_iterations : int, optional (default=15)
         Maximum number of iterations without improvement before termination.
+    multistart : int, optional (default=1)
+        Number of optimiser restarts from randomly sample position. These positions
+        are sampled from the priors.
     parallel : bool, optional (default=False)
         Whether to run the optimisation in parallel.
     **optimiser_kwargs : optional
@@ -535,6 +573,7 @@ class NelderMead(BasePintsOptimiser):
         max_iterations: int = None,
         min_iterations: int = 2,
         max_unchanged_iterations: int = 15,
+        multistart: int = 1,
         parallel: bool = False,
         **optimiser_kwargs,
     ):
@@ -544,6 +583,7 @@ class NelderMead(BasePintsOptimiser):
             max_iterations,
             min_iterations,
             max_unchanged_iterations,
+            multistart,
             parallel,
             **optimiser_kwargs,
         )
@@ -567,6 +607,9 @@ class CMAES(BasePintsOptimiser):
         Minimum number of iterations before termination.
     max_unchanged_iterations : int, optional (default=15)
         Maximum number of iterations without improvement before termination.
+    multistart : int, optional (default=1)
+        Number of optimiser restarts from randomly sample position. These positions
+        are sampled from the priors.
     parallel : bool, optional (default=False)
         Whether to run the optimisation in parallel.
     **optimiser_kwargs : optional
@@ -600,6 +643,7 @@ class CMAES(BasePintsOptimiser):
         max_iterations: int = None,
         min_iterations: int = 2,
         max_unchanged_iterations: int = 15,
+        multistart: int = 1,
         parallel: bool = False,
         **optimiser_kwargs,
     ):
@@ -615,6 +659,7 @@ class CMAES(BasePintsOptimiser):
             max_iterations,
             min_iterations,
             max_unchanged_iterations,
+            multistart,
             parallel,
             **optimiser_kwargs,
         )
@@ -637,6 +682,9 @@ class CuckooSearch(BasePintsOptimiser):
         Minimum number of iterations before termination.
     max_unchanged_iterations : int, optional (default=15)
         Maximum number of iterations without improvement before termination.
+    multistart : int, optional (default=1)
+        Number of optimiser restarts from randomly sample position. These positions
+        are sampled from the priors.
     parallel : bool, optional (default=False)
         Whether to run the optimisation in parallel.
     **optimiser_kwargs : optional
@@ -670,6 +718,7 @@ class CuckooSearch(BasePintsOptimiser):
         max_iterations: int = None,
         min_iterations: int = 2,
         max_unchanged_iterations: int = 15,
+        multistart: int = 1,
         parallel: bool = False,
         **optimiser_kwargs,
     ):
@@ -679,6 +728,7 @@ class CuckooSearch(BasePintsOptimiser):
             max_iterations,
             min_iterations,
             max_unchanged_iterations,
+            multistart,
             parallel,
             **optimiser_kwargs,
         )


### PR DESCRIPTION
# Description

Adds multi-start functionality to Pints' and SciPy optimisers.

ToDo:

- [ ] Add integration and unit tests
- [ ] Verify plotting and updates to optimiser log for multi-start storage

## Issue reference
Fixes #438 

## Review
Before you mark your PR as ready for review, please ensure that you've considered the following:
- Updated the [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) in reverse chronological order (newest at the top) with a concise description of the changes, including the PR number.
- Noted any breaking changes, including details on how it might impact existing functionality.

## Type of change
- [X] New Feature: A non-breaking change that adds new functionality.
- [ ] Optimization: A code change that improves performance.
- [ ] Examples: A change to existing or additional examples.
- [ ] Bug Fix: A non-breaking change that addresses an issue.
- [ ] Documentation: Updates to documentation or new documentation for new features.
- [ ] Refactoring: Non-functional changes that improve the codebase.
- [ ] Style: Non-functional changes related to code style (formatting, naming, etc).
- [ ] Testing: Additional tests to improve coverage or confirm functionality.
- [ ] Other: (Insert description of change)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All unit tests pass: `$ nox -s tests`
- [ ] The documentation builds: `$ nox -s doctest`

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:
- [ ] Code is well-commented, especially in complex or unclear areas.
- [ ] Added tests that prove my fix is effective or that my feature works.
- [ ] Checked that coverage remains or improves, and added tests if necessary to maintain or increase coverage.

Thank you for contributing to our project! Your efforts help us to deliver great software.
