### PR TITLE
Fix bug with old PyBaMM version being fetched for scheduled tests

### DIFF
--- a/scripts/ci/build_matrix.sh
+++ b/scripts/ci/build_matrix.sh
@@ -15,7 +15,7 @@ os=("ubuntu-latest" "windows-latest" "macos-13" "macos-14")
 pybamm_version=($(curl -s https://pypi.org/pypi/pybamm/json | jq -r '.releases | keys[]' | grep -v rc | sort -V | tail -n 1 | paste -sd " " -))
 
 # This command fetches the last PyBaMM versions including release candidates from PyPI
-#pybamm_version=($(curl -s https://pypi.org/pypi/pybamm/json | jq -r '.releases | keys[]' | tail -n 1 | paste -sd " " -))
+#pybamm_version=($(curl -s https://pypi.org/pypi/pybamm/json | jq -r '.releases | keys[]' | sort -V | tail -n 1 | paste -sd " " -))
 
 # open dict
 json='{

--- a/scripts/ci/build_matrix.sh
+++ b/scripts/ci/build_matrix.sh
@@ -12,7 +12,7 @@
 python_version=("3.9" "3.10" "3.11" "3.12")
 os=("ubuntu-latest" "windows-latest" "macos-13" "macos-14")
 # This command fetches the last PyBaMM version excluding release candidates from PyPI
-pybamm_version=($(curl -s https://pypi.org/pypi/pybamm/json | jq -r '.releases | keys[]' | grep -v rc | tail -n 1 | paste -sd " " -))
+pybamm_version=($(curl -s https://pypi.org/pypi/pybamm/json | jq -r '.releases | keys[]' | grep -v rc | sort -V | tail -n 1 | paste -sd " " -))
 
 # This command fetches the last PyBaMM versions including release candidates from PyPI
 #pybamm_version=($(curl -s https://pypi.org/pypi/pybamm/json | jq -r '.releases | keys[]' | tail -n 1 | paste -sd " " -))


### PR DESCRIPTION
# Description

This is a small PR that fixes a sorting bug I noticed in the scheduled tests where the [current iteration](https://github.com/pybop-team/PyBOP/actions/workflows/scheduled_tests.yaml) of them is being run against PyBaMM 24.9, even though PyBaMM 24.11.2 is now released and up on PyPI. The problem was that `jq` orders the releases by comparing the string's characters from left to right, and hence it does not understand the semantics of versioning schemas that we do, i.e., that 24.11 comes after 24.9 as far as software versions are concerned. The `sort` interprets them like numbers.

Before this PR: `24.9.0`
After sorting: `24.11.2`

## Issue reference

N/A

## Review
Before you mark your PR as ready for review, please ensure that you've considered the following:
- Updated the [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) in reverse chronological order (newest at the top) with a concise description of the changes, including the PR number.
- Noted any breaking changes, including details on how it might impact existing functionality.

## Type of change
- [ ] New Feature: A non-breaking change that adds new functionality.
- [ ] Optimization: A code change that improves performance.
- [ ] Examples: A change to existing or additional examples.
- [x] Bug Fix: A non-breaking change that addresses an issue.
- [ ] Documentation: Updates to documentation or new documentation for new features.
- [ ] Refactoring: Non-functional changes that improve the codebase.
- [ ] Style: Non-functional changes related to code style (formatting, naming, etc).
- [x] Testing: Additional tests to improve coverage or confirm functionality.
- [ ] Other: (Insert description of change)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All unit tests pass: `$ nox -s tests`
- [x] The documentation builds: `$ nox -s doctest`

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:
- [ ] Code is well-commented, especially in complex or unclear areas.
- [ ] Added tests that prove my fix is effective or that my feature works.
- [ ] Checked that coverage remains or improves, and added tests if necessary to maintain or increase coverage.

Thank you for contributing to our project! Your efforts help us to deliver great software.
