### PR TITLE
Add naming utility

### DIFF
--- a/pybop/_utils.py
+++ b/pybop/_utils.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import numpy as np
 import pybamm
+import regex as re
 
 
 def is_numeric(x):
@@ -9,6 +10,15 @@ def is_numeric(x):
     Check if a variable is numeric.
     """
     return isinstance(x, (int, float, np.number))
+
+
+def add_spaces(string):
+    """
+    Return the class name as a string with spaces before each new capitalised word.
+    """
+    re_outer = re.compile(r"([^A-Z ])([A-Z])")
+    re_inner = re.compile(r"(?<!^)([A-Z])([^A-Z])")
+    return re_outer.sub(r"\1 \2", re_inner.sub(r" \1\2", string))
 
 
 class SymbolReplacer:

--- a/pybop/costs/base_cost.py
+++ b/pybop/costs/base_cost.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy import ndarray
 
 from pybop import BaseProblem
+from pybop._utils import add_spaces
 from pybop.parameters.parameter import Inputs, Parameters
 
 
@@ -195,6 +196,10 @@ class BaseCost:
         self._parameters.join(parameters)
         if original_n_params != self.n_parameters:
             self.set_fail_gradient()
+
+    @property
+    def name(self):
+        return add_spaces(type(self).__name__)
 
     @property
     def n_parameters(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "numpy>=1.16, <2.0",
   "scipy>=1.3",
   "pints>=0.5",
+  "regex",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -235,19 +235,20 @@ class TestCosts:
         )
 
     @pytest.mark.parametrize(
-        "cost_class",
+        "cost_class, expected_name",
         [
-            pybop.DesignCost,
-            pybop.GravimetricEnergyDensity,
-            pybop.VolumetricEnergyDensity,
-            pybop.GravimetricPowerDensity,
-            pybop.VolumetricPowerDensity,
+            (pybop.DesignCost, "Design Cost"),
+            (pybop.GravimetricEnergyDensity, "Gravimetric Energy Density"),
+            (pybop.VolumetricEnergyDensity, "Volumetric Energy Density"),
+            (pybop.GravimetricPowerDensity, "Gravimetric Power Density"),
+            (pybop.VolumetricPowerDensity, "Volumetric Power Density"),
         ],
     )
     @pytest.mark.unit
-    def test_design_costs(self, cost_class, design_problem):
+    def test_design_costs(self, cost_class, expected_name, design_problem):
         # Construct Cost
         cost = cost_class(design_problem)
+        assert cost.name == expected_name
 
         if cost_class in [pybop.DesignCost]:
             with pytest.raises(NotImplementedError):


### PR DESCRIPTION
# Description

Adds a regex-based utility to enable automatic extraction of a cost class name for figure legends.

## Issue reference
Show feature

## Review
Before you mark your PR as ready for review, please ensure that you've considered the following:
- Updated the [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) in reverse chronological order (newest at the top) with a concise description of the changes, including the PR number.
- Noted any breaking changes, including details on how it might impact existing functionality.

## Type of change
- [ ] New Feature: A non-breaking change that adds new functionality.
- [ ] Optimization: A code change that improves performance.
- [ ] Examples: A change to existing or additional examples.
- [ ] Bug Fix: A non-breaking change that addresses an issue.
- [ ] Documentation: Updates to documentation or new documentation for new features.
- [ ] Refactoring: Non-functional changes that improve the codebase.
- [ ] Style: Non-functional changes related to code style (formatting, naming, etc).
- [ ] Testing: Additional tests to improve coverage or confirm functionality.
- [ ] Other: (Insert description of change)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All unit tests pass: `$ nox -s tests`
- [ ] The documentation builds: `$ nox -s doctest`

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:
- [ ] Code is well-commented, especially in complex or unclear areas.
- [ ] Added tests that prove my fix is effective or that my feature works.
- [ ] Checked that coverage remains or improves, and added tests if necessary to maintain or increase coverage.

Thank you for contributing to our project! Your efforts help us to deliver great software.
