### PR TITLE
Fixes #581 - `population_size` setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- [#582](https://github.com/pybop-team/PyBOP/pull/582) - Fixes `population_size` arg for Pints' based optimisers, reshapes `parameters.rvs` to be parameter instances.
 - [#570](https://github.com/pybop-team/PyBOP/pull/570) - Updates the contour and surface plots, adds mixed chain effective sample size computation, x0 to optim.log
 - [#566](https://github.com/pybop-team/PyBOP/pull/566) - Adds `UnitHyperCube` transformation class, fixes incorrect application of gradient transformation.
 - [#569](https://github.com/pybop-team/PyBOP/pull/569) - Adds parameter specific learning rate functionality to GradientDescent optimiser.

--- a/pybop/optimisers/base_pints_optimiser.py
+++ b/pybop/optimisers/base_pints_optimiser.py
@@ -119,7 +119,9 @@ class BasePintsOptimiser(BaseOptimiser):
                 max_unchanged_kwargs[tol_key] = self.unset_options.pop(tol_key)
 
         # Set population size (if applicable)
-        self._set_population_size()
+        if "population_size" in self.unset_options:
+            population_size = self.unset_options.pop("population_size")
+            self.set_population_size(population_size)
 
     def _sanitise_inputs(self):
         """
@@ -519,12 +521,9 @@ class BasePintsOptimiser(BaseOptimiser):
         else:
             self._threshold = float(threshold)
 
-    def _set_population_size(self):
+    def set_population_size(self, population_size=None):
         """
         Set the population size for population-based optimisers, if specified.
         """
-        if "population_size" in self.unset_options and isinstance(
-            self.optimiser, PopulationBasedOptimiser
-        ):
-            population_size = self.unset_options.pop("population_size")
+        if isinstance(self.optimiser, PopulationBasedOptimiser):
             self.optimiser.set_population_size(population_size)

--- a/pybop/optimisers/base_pints_optimiser.py
+++ b/pybop/optimisers/base_pints_optimiser.py
@@ -6,6 +6,7 @@ from pints import Adam as PintsAdam
 from pints import NelderMead as PintsNelderMead
 from pints import Optimiser as PintsOptimiser
 from pints import ParallelEvaluator as PintsParallelEvaluator
+from pints import PopulationBasedOptimiser
 from pints import PopulationBasedOptimiser as PintsPopulationBasedOptimiser
 from pints import RectangularBoundaries as PintsRectangularBoundaries
 from pints import SequentialEvaluator as PintsSequentialEvaluator
@@ -116,6 +117,9 @@ class BasePintsOptimiser(BaseOptimiser):
         for tol_key in ["absolute_tolerance", "relative_tolerance"]:
             if tol_key in self.unset_options:
                 max_unchanged_kwargs[tol_key] = self.unset_options.pop(tol_key)
+
+        # Set population size (if applicable)
+        self._set_population_size()
 
     def _sanitise_inputs(self):
         """
@@ -514,3 +518,13 @@ class BasePintsOptimiser(BaseOptimiser):
             self._threshold = None
         else:
             self._threshold = float(threshold)
+
+    def _set_population_size(self):
+        """
+        Set the population size for population-based optimisers, if specified.
+        """
+        if "population_size" in self.unset_options and isinstance(
+            self.optimiser, PopulationBasedOptimiser
+        ):
+            population_size = self.unset_options.pop("population_size")
+            self.optimiser.set_population_size(population_size)

--- a/pybop/parameters/parameter.py
+++ b/pybop/parameters/parameter.py
@@ -399,6 +399,9 @@ class Parameters:
             samples = param.rvs(n_samples, apply_transform=apply_transform)
             all_samples.append(samples)
 
+        if n_samples > 1:
+            return np.asarray(all_samples).T
+
         return np.concatenate(all_samples)
 
     def get_sigma0(self, apply_transform: bool = False) -> list:

--- a/tests/unit/test_optimisation.py
+++ b/tests/unit/test_optimisation.py
@@ -4,6 +4,7 @@ import sys
 import warnings
 
 import numpy as np
+import pints
 import pytest
 
 import pybop
@@ -206,6 +207,13 @@ class TestOptimisation:
                 warnings.simplefilter("always")
                 optimiser(cost=cost, unrecognised=10)
             assert not optim.optimiser.running()
+
+            # Check population setter
+            if isinstance(optim.optimiser, pints.PopulationBasedOptimiser):
+                optim = pybop.Optimisation(
+                    cost=cost, optimiser=optimiser, population_size=100
+                )
+                assert optim.optimiser.population_size() == 100
         else:
             bounds_list = [
                 (lower, upper) for lower, upper in zip(bounds["lower"], bounds["upper"])

--- a/tests/unit/test_optimisation.py
+++ b/tests/unit/test_optimisation.py
@@ -4,8 +4,8 @@ import sys
 import warnings
 
 import numpy as np
-import pints
 import pytest
+from pints import PopulationBasedOptimiser
 
 import pybop
 
@@ -209,7 +209,7 @@ class TestOptimisation:
             assert not optim.optimiser.running()
 
             # Check population setter
-            if isinstance(optim.optimiser, pints.PopulationBasedOptimiser):
+            if isinstance(optim.optimiser, PopulationBasedOptimiser):
                 optim = pybop.Optimisation(
                     cost=cost, optimiser=optimiser, population_size=100
                 )


### PR DESCRIPTION
# Description

Adds population size setter, updates `parameters.rvs(`) to return parameter instances when the number of samples requested is > 1

## Issue reference
Fixes #581 

## Review
Before you mark your PR as ready for review, please ensure that you've considered the following:
- Updated the [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) in reverse chronological order (newest at the top) with a concise description of the changes, including the PR number.
- Noted any breaking changes, including details on how it might impact existing functionality.

## Type of change
- [ ] New Feature: A non-breaking change that adds new functionality.
- [ ] Optimization: A code change that improves performance.
- [ ] Examples: A change to existing or additional examples.
- [X] Bug Fix: A non-breaking change that addresses an issue.
- [ ] Documentation: Updates to documentation or new documentation for new features.
- [ ] Refactoring: Non-functional changes that improve the codebase.
- [ ] Style: Non-functional changes related to code style (formatting, naming, etc).
- [ ] Testing: Additional tests to improve coverage or confirm functionality.
- [ ] Other: (Insert description of change)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All unit tests pass: `$ nox -s tests`
- [ ] The documentation builds: `$ nox -s doctest`

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:
- [ ] Code is well-commented, especially in complex or unclear areas.
- [ ] Added tests that prove my fix is effective or that my feature works.
- [ ] Checked that coverage remains or improves, and added tests if necessary to maintain or increase coverage.

Thank you for contributing to our project! Your efforts help us to deliver great software.
