### PR TITLE
Removes depreciated `Adam` optimiser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ## Breaking Changes
 
+- [#598](https://github.com/pybop-team/PyBOP/pull/598) - Depreciated `Adam` optimiser has been removed, see `AdamW` for replacement.
 - [#531](https://github.com/pybop-team/PyBOP/pull/531) - Plot methods moved to `pybop.plot` with mostly minimal renaming. For example, `pybop.plot_parameters` is now `pybop.plot.parameters`. Other breaking changes include: `pybop.plot2d` to `pybop.plot.contour`.
 - [#526](https://github.com/pybop-team/PyBOP/pull/526) - Refactor `OptimisationResults` classes, with `optim.run()` now return the full object. Adds finite cost value check for optimised parameters.
 

--- a/pybop/__init__.py
+++ b/pybop/__init__.py
@@ -134,7 +134,6 @@ from .optimisers.scipy_optimisers import (
 )
 from .optimisers.pints_optimisers import (
     GradientDescent,
-    Adam,
     CMAES,
     IRPropMin,
     NelderMead,

--- a/pybop/optimisers/base_pints_optimiser.py
+++ b/pybop/optimisers/base_pints_optimiser.py
@@ -2,7 +2,6 @@ from time import time
 
 import numpy as np
 from pints import PSO as PintsPSO
-from pints import Adam as PintsAdam
 from pints import NelderMead as PintsNelderMead
 from pints import Optimiser as PintsOptimiser
 from pints import ParallelEvaluator as PintsParallelEvaluator
@@ -12,7 +11,7 @@ from pints import RectangularBoundaries as PintsRectangularBoundaries
 from pints import SequentialEvaluator as PintsSequentialEvaluator
 from pints import strfloat as PintsStrFloat
 
-from pybop import BaseOptimiser, GradientDescentImpl, OptimisationResult
+from pybop import AdamWImpl, BaseOptimiser, GradientDescentImpl, OptimisationResult
 
 
 class BasePintsOptimiser(BaseOptimiser):
@@ -143,7 +142,7 @@ class BasePintsOptimiser(BaseOptimiser):
 
         # Convert bounds to PINTS boundaries
         if self.bounds is not None:
-            ignored_optimisers = (GradientDescentImpl, PintsAdam, PintsNelderMead)
+            ignored_optimisers = (GradientDescentImpl, AdamWImpl, PintsNelderMead)
             if issubclass(self._pints_optimiser, ignored_optimisers):
                 print(f"NOTE: Boundaries ignored by {self._pints_optimiser}")
                 self.bounds = None

--- a/pybop/optimisers/pints_optimisers.py
+++ b/pybop/optimisers/pints_optimisers.py
@@ -1,10 +1,7 @@
-from warnings import warn
-
 from pints import CMAES as PintsCMAES
 from pints import PSO as PintsPSO
 from pints import SNES as PintsSNES
 from pints import XNES as PintsXNES
-from pints import Adam as PintsAdam
 from pints import IRPropMin as PintsIRPropMin
 from pints import NelderMead as PintsNelderMead
 
@@ -78,83 +75,6 @@ class GradientDescent(BasePintsOptimiser):
         super().__init__(
             cost,
             GradientDescentImpl,
-            max_iterations,
-            min_iterations,
-            max_unchanged_iterations,
-            multistart,
-            parallel,
-            **optimiser_kwargs,
-        )
-
-
-class Adam(BasePintsOptimiser):
-    """
-    Implements the Adam optimisation algorithm.
-
-    This class extends the Adam optimiser from the PINTS library, which combines
-    ideas from RMSProp and Stochastic Gradient Descent with momentum.
-
-    Note that this optimiser does not support boundary constraints.
-
-    Parameters
-    ----------
-    cost : callable
-        The cost function to be minimized.
-    max_iterations : int, optional
-        Maximum number of iterations for the optimisation.
-    min_iterations : int, optional (default=2)
-        Minimum number of iterations before termination.
-    max_unchanged_iterations : int, optional (default=15)
-        Maximum number of iterations without improvement before termination.
-    multistart : int, optional (default=1)
-        Number of optimiser restarts from randomly sample position. These positions
-        are sampled from the priors.
-    parallel : bool, optional (default=False)
-        Whether to run the optimisation in parallel.
-    **optimiser_kwargs : optional
-        Valid PINTS option keys and their values, for example:
-        x0 : array_like
-            Initial position from which optimisation will start.
-        sigma0 : float
-            Initial step size or standard deviation depending on the optimiser.
-        bounds : dict
-            A dictionary with 'lower' and 'upper' keys containing arrays for lower and
-            upper bounds on the parameters.
-        use_f_guessed : bool
-            Whether to return the guessed function values.
-        absolute_tolerance : float
-            Absolute tolerance for convergence checking.
-        relative_tolerance : float
-            Relative tolerance for convergence checking.
-        max_evaluations : int
-            Maximum number of function evaluations.
-        threshold : float
-            Threshold value for early termination.
-
-    See Also
-    --------
-    pints.Adam : The PINTS implementation this class is based on.
-    """
-
-    warn(
-        "Adam is deprecated and will be removed in a future release. Please use AdamW instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
-    def __init__(
-        self,
-        cost,
-        max_iterations: int = None,
-        min_iterations: int = 2,
-        max_unchanged_iterations: int = 15,
-        multistart: int = 1,
-        parallel: bool = False,
-        **optimiser_kwargs,
-    ):
-        super().__init__(
-            cost,
-            PintsAdam,
             max_iterations,
             min_iterations,
             max_unchanged_iterations,

--- a/tests/unit/test_optimisation.py
+++ b/tests/unit/test_optimisation.py
@@ -76,7 +76,6 @@ class TestOptimisation:
             (pybop.SciPyMinimize, "SciPyMinimize", False),
             (pybop.SciPyDifferentialEvolution, "SciPyDifferentialEvolution", False),
             (pybop.GradientDescent, "Gradient descent", True),
-            (pybop.Adam, "Adam", True),
             (pybop.AdamW, "AdamW", True),
             (
                 pybop.CMAES,
@@ -131,7 +130,6 @@ class TestOptimisation:
             pybop.SciPyMinimize,
             pybop.SciPyDifferentialEvolution,
             pybop.GradientDescent,
-            pybop.Adam,
             pybop.AdamW,
             pybop.SNES,
             pybop.XNES,
@@ -184,7 +182,7 @@ class TestOptimisation:
         multistart_optim = optimiser(cost, multistart=2, max_iterations=6)
         check_multistart(multistart_optim, 6, 2)
 
-        if optimiser in [pybop.GradientDescent, pybop.Adam, pybop.NelderMead]:
+        if optimiser in [pybop.GradientDescent, pybop.AdamW, pybop.NelderMead]:
             optim = optimiser(cost=cost, bounds=cost_bounds)
             assert optim.bounds is None
         elif optimiser in [pybop.PSO]:


### PR DESCRIPTION
# Description

Removes depreciated `Adam` optimiser, see `AdamW` for replacement.

## Issue reference
Fixes #295 

## Review
Before you mark your PR as ready for review, please ensure that you've considered the following:
- Updated the [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) in reverse chronological order (newest at the top) with a concise description of the changes, including the PR number.
- Noted any breaking changes, including details on how it might impact existing functionality.

## Type of change
- [ ] New Feature: A non-breaking change that adds new functionality.
- [ ] Optimization: A code change that improves performance.
- [ ] Examples: A change to existing or additional examples.
- [ ] Bug Fix: A non-breaking change that addresses an issue.
- [ ] Documentation: Updates to documentation or new documentation for new features.
- [ ] Refactoring: Non-functional changes that improve the codebase.
- [ ] Style: Non-functional changes related to code style (formatting, naming, etc).
- [ ] Testing: Additional tests to improve coverage or confirm functionality.
- [ ] Other: (Insert description of change)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All unit tests pass: `$ nox -s tests`
- [ ] The documentation builds: `$ nox -s doctest`

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:
- [ ] Code is well-commented, especially in complex or unclear areas.
- [ ] Added tests that prove my fix is effective or that my feature works.
- [ ] Checked that coverage remains or improves, and added tests if necessary to maintain or increase coverage.

Thank you for contributing to our project! Your efforts help us to deliver great software.
