### PR TITLE
Update the GroupedSPMe spatial variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Optimisations
 
+- [#681](https://github.com/pybop-team/PyBOP/pull/681) - Update the spatial variable defaults of the `GroupedSPMe` model.
+
 ## Bug Fixes
 
 - [#678](https://github.com/pybop-team/PyBOP/pull/678) - Fixed bug where model wasn't plotted for observer classes with `pybop.plot.quick()`.

--- a/pybop/models/lithium_ion/basic_SPMe.py
+++ b/pybop/models/lithium_ion/basic_SPMe.py
@@ -9,6 +9,7 @@ from pybamm import (
     ParameterValues,
     PrimaryBroadcast,
     Scalar,
+    SpatialVariable,
     Variable,
 )
 from pybamm import lithium_ion as pybamm_lithium_ion
@@ -32,6 +33,26 @@ class BaseGroupedSPMe(pybamm_lithium_ion.BaseModel):
     ----------
     name : str, optional
         The name of the model.
+    eis : bool, optional
+        A flag to build the forward model for EIS predictions. Defaults to False.
+    **model_kwargs : optional
+        Valid PyBaMM model option keys and their values, for example:
+        parameter_set : pybamm.ParameterValues or dict, optional
+            The parameters for the model. If None, default parameters provided by PyBaMM are used.
+        geometry : dict, optional
+            The geometry definitions for the model. If None, default geometry from PyBaMM is used.
+        submesh_types : dict, optional
+            The types of submeshes to use. If None, default submesh types from PyBaMM are used.
+        var_pts : dict, optional
+            The discretization points for each variable in the model. If None, default points from PyBaMM are used.
+        spatial_methods : dict, optional
+            The spatial methods used for discretization. If None, default spatial methods from PyBaMM are used.
+        solver : pybamm.Solver, optional
+            The solver to use for simulating the model. If None, the default solver from PyBaMM is used.
+        build : bool, optional
+            If True, the model is built upon creation (default: False).
+        options : dict, optional
+            A dictionary of options to customise the behaviour of the PyBaMM model.
     """
 
     def __init__(
@@ -98,8 +119,8 @@ class BaseGroupedSPMe(pybamm_lithium_ion.BaseModel):
         )
 
         # Spatial variables
-        x_n = pybamm.SpatialVariable("x_n", ["negative electrode"])
-        x_p = pybamm.SpatialVariable("x_p", ["positive electrode"])
+        x_n = SpatialVariable("x_n", domain=["negative electrode"])
+        x_p = SpatialVariable("x_p", domain=["positive electrode"])
 
         # Surf takes the surface value of a variable, i.e. its boundary value on the
         # right side. This is also accessible via `boundary_value(x, "right")`, with
@@ -155,8 +176,8 @@ class BaseGroupedSPMe(pybamm_lithium_ion.BaseModel):
         tau_ct_p = Parameter("Positive electrode charge transfer time scale [s]")
         tau_ct_n = Parameter("Negative electrode charge transfer time scale [s]")
 
-        l_p = Parameter("Positive electrode thickness [m]")  # normalised
-        l_n = Parameter("Negative electrode thickness [m]")  # normalised
+        l_p = Parameter("Positive electrode relative thickness")
+        l_n = Parameter("Negative electrode relative thickness")
 
         t_plus = Parameter("Cation transference number")
 
@@ -386,6 +407,40 @@ class BaseGroupedSPMe(pybamm_lithium_ion.BaseModel):
             "Open-circuit voltage [V]": U_p - U_n,
         }
 
+    def U(self, sto, domain):
+        """
+        Dimensional open-circuit potential [V], calculated as U(x) = U_ref(x).
+        Credit: PyBaMM
+        """
+        # bound stoichiometry between tol and 1-tol. Adding 1/sto + 1/(sto-1) later
+        # will ensure that ocp goes to +- infinity if sto goes into that region
+        # anyway
+        Domain = domain.capitalize()
+        tol = pybamm.settings.tolerances["U__c_s"]
+        sto = pybamm.maximum(pybamm.minimum(sto, 1 - tol), tol)
+        inputs = {f"{Domain} particle surface stoichiometry": sto}
+        u_ref = FunctionParameter(f"{Domain} electrode OCP [V]", inputs)
+
+        # add a term to ensure that the OCP goes to infinity at 0 and -infinity at 1
+        # this will not affect the OCP for most values of sto
+        out = u_ref + 1e-6 * (1 / sto + 1 / (sto - 1))
+
+        if domain == "negative":
+            out.print_name = r"U_\mathrm{n}(c^\mathrm{surf}_\mathrm{s,n})"
+        elif domain == "positive":
+            out.print_name = r"U_\mathrm{p}(c^\mathrm{surf}_\mathrm{s,p})"
+        return out
+
+    def build_model(self):
+        """
+        Build model variables and equations
+        Credit: PyBaMM
+        """
+        self._build_model()
+
+        self._built = True
+        pybamm.logger.info(f"Finish building {self.name}")
+
     @property
     def default_parameter_values(self):
         parameter_dictionary = {
@@ -415,48 +470,11 @@ class BaseGroupedSPMe(pybamm_lithium_ion.BaseModel):
             "Positive electrode capacitance [F]": 1,
             "Negative electrode capacitance [F]": 1,
             "Cation transference number": 0.25,
-            "Positive electrode thickness [m]": 0.47,  # normalised
-            "Negative electrode thickness [m]": 0.47,  # normalised
-            "Separator thickness [m]": 0.06,  # normalised
-            "Positive particle radius [m]": 1,  # normalised
-            "Negative particle radius [m]": 1,  # normalised
+            "Positive electrode relative thickness": 0.47,
+            "Negative electrode relative thickness": 0.47,
             "Series resistance [Ohm]": 0.01,
         }
         return ParameterValues(values=parameter_dictionary)
-
-    def build_model(self):
-        """
-        Build model variables and equations
-        Credit: PyBaMM
-        """
-        self._build_model()
-
-        self._built = True
-        pybamm.logger.info(f"Finish building {self.name}")
-
-    def U(self, sto, domain):
-        """
-        Dimensional open-circuit potential [V], calculated as U(x) = U_ref(x).
-        Credit: PyBaMM
-        """
-        # bound stoichiometry between tol and 1-tol. Adding 1/sto + 1/(sto-1) later
-        # will ensure that ocp goes to +- infinity if sto goes into that region
-        # anyway
-        Domain = domain.capitalize()
-        tol = pybamm.settings.tolerances["U__c_s"]
-        sto = pybamm.maximum(pybamm.minimum(sto, 1 - tol), tol)
-        inputs = {f"{Domain} particle surface stoichiometry": sto}
-        u_ref = FunctionParameter(f"{Domain} electrode OCP [V]", inputs)
-
-        # add a term to ensure that the OCP goes to infinity at 0 and -infinity at 1
-        # this will not affect the OCP for most values of sto
-        out = u_ref + 1e-6 * (1 / sto + 1 / (sto - 1))
-
-        if domain == "negative":
-            out.print_name = r"U_\mathrm{n}(c^\mathrm{surf}_\mathrm{s,n})"
-        elif domain == "positive":
-            out.print_name = r"U_\mathrm{p}(c^\mathrm{surf}_\mathrm{s,p})"
-        return out
 
     @property
     def default_quick_plot_variables(self):
@@ -476,6 +494,73 @@ class BaseGroupedSPMe(pybamm_lithium_ion.BaseModel):
             },
             {"Open-circuit voltage [V]", "Voltage [V]"},
         ]
+
+    @property
+    def default_var_pts(self):
+        x_n = pybamm.SpatialVariable(
+            "x_n",
+            domain=["negative electrode"],
+            coord_sys="cartesian",
+        )
+        x_s = pybamm.SpatialVariable(
+            "x_s",
+            domain=["separator"],
+            coord_sys="cartesian",
+        )
+        x_p = pybamm.SpatialVariable(
+            "x_p",
+            domain=["positive electrode"],
+            coord_sys="cartesian",
+        )
+
+        # Add particle domains
+        r_n = pybamm.SpatialVariable(
+            "r_n",
+            domain=["negative particle"],
+            auxiliary_domains={"secondary": "negative electrode"},
+            coord_sys="spherical polar",
+        )
+        r_p = pybamm.SpatialVariable(
+            "r_p",
+            domain=["positive particle"],
+            auxiliary_domains={"secondary": "positive electrode"},
+            coord_sys="spherical polar",
+        )
+
+        return {x_n: 20, x_s: 20, x_p: 20, r_n: 20, r_p: 20}
+
+    @property
+    def default_geometry(self):
+        l_p = Parameter("Positive electrode relative thickness")
+        l_n = Parameter("Negative electrode relative thickness")
+
+        return {
+            "negative electrode": {"x_n": {"min": 0, "max": l_n}},
+            "separator": {"x_s": {"min": l_n, "max": 1 - l_p}},
+            "positive electrode": {"x_p": {"min": 1 - l_p, "max": 1}},
+            "negative particle": {"r_n": {"min": 0, "max": 1}},
+            "positive particle": {"r_p": {"min": 0, "max": 1}},
+        }
+
+    @property
+    def default_submesh_types(self):
+        return {
+            "negative electrode": pybamm.Uniform1DSubMesh,
+            "separator": pybamm.Uniform1DSubMesh,
+            "positive electrode": pybamm.Uniform1DSubMesh,
+            "negative particle": pybamm.Uniform1DSubMesh,
+            "positive particle": pybamm.Uniform1DSubMesh,
+        }
+
+    @property
+    def default_spatial_methods(self):
+        return {
+            "negative electrode": pybamm.FiniteVolume(),
+            "separator": pybamm.FiniteVolume(),
+            "positive electrode": pybamm.FiniteVolume(),
+            "negative particle": pybamm.FiniteVolume(),
+            "positive particle": pybamm.FiniteVolume(),
+        }
 
 
 def convert_physical_to_grouped_parameters(parameter_set):

--- a/pybop/models/lithium_ion/echem.py
+++ b/pybop/models/lithium_ion/echem.py
@@ -313,44 +313,6 @@ class GroupedSPMe(EChemBaseModel):
         eis=False,
         **model_kwargs,
     ):
-        # Use normalised lengthscales
-        parameter_set = model_kwargs.pop("parameter_set", None)
-        default_parameter_set = BaseGroupedSPMe().default_parameter_values
-        if parameter_set:
-            parameter_set.update(
-                {
-                    "Positive electrode thickness [m]": default_parameter_set[
-                        "Positive electrode thickness [m]"
-                    ],
-                    "Negative electrode thickness [m]": default_parameter_set[
-                        "Negative electrode thickness [m]"
-                    ],
-                },
-                check_already_exists=False,
-            )
-            # Update dimensions to equal their dimensionless values
-            if "Positive electrode relative thickness" in parameter_set.keys():
-                parameter_set["Positive electrode thickness [m]"] = parameter_set[
-                    "Positive electrode relative thickness"
-                ]
-            if "Negative electrode relative thickness" in parameter_set.keys():
-                parameter_set["Negative electrode thickness [m]"] = parameter_set[
-                    "Negative electrode relative thickness"
-                ]
-            parameter_set.update(
-                {
-                    "Separator thickness [m]": (
-                        1
-                        - parameter_set["Positive electrode thickness [m]"]
-                        - parameter_set["Negative electrode thickness [m]"]
-                    ),
-                    "Positive particle radius [m]": 1,
-                    "Negative particle radius [m]": 1,
-                },
-                check_already_exists=False,
-            )
-            model_kwargs["parameter_set"] = parameter_set
-
         super().__init__(
             pybamm_model=BaseGroupedSPMe, name=name, eis=eis, **model_kwargs
         )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -567,16 +567,20 @@ class TestModels:
             atol=1e-8,
         )
 
-    def test_grouped_SPMe(self):
+    @pytest.mark.parametrize(
+        "model_class",
+        [
+            pybop.lithium_ion.WeppnerHuggins,
+            pybop.lithium_ion.GroupedSPMe,
+        ],
+    )
+    def test_custom_models(self, model_class):
         with pytest.warns(UserWarning) as record:
-            model = pybop.lithium_ion.GroupedSPMe(
-                unused_kwarg=0, options={"unused option": 0}
-            )
+            model_class(unused_kwarg=0, options={"unused option": 0})
             assert "The input model_kwargs" in str(record[0].message)
-            assert "are not currently used by the GroupedSPMe." in str(
-                record[0].message
-            )
+            assert "are not currently used by " in str(record[0].message)
 
+    def test_grouped_SPMe(self):
         parameter_set = pybop.ParameterSet.pybamm("Chen2020")
         parameter_set["Electrolyte diffusivity [m2.s-1]"] = 1.769e-10
         parameter_set["Electrolyte conductivity [S.m-1]"] = 0.9487


### PR DESCRIPTION
# Description

Update the default `var_pts`, `geometry`, `submesh_types` and `spatial_methods` for the `GroupedSPMe` model to align with the dimensionless variables used in the model.

## Issue reference
Show fix

## Review
Before you mark your PR as ready for review, please ensure that you've considered the following:
- Updated the [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) in reverse chronological order (newest at the top) with a concise description of the changes, including the PR number.
- Noted any breaking changes, including details on how it might impact existing functionality.

## Type of change
- [ ] New Feature: A non-breaking change that adds new functionality.
- [ ] Optimization: A code change that improves performance.
- [ ] Examples: A change to existing or additional examples.
- [ ] Bug Fix: A non-breaking change that addresses an issue.
- [ ] Documentation: Updates to documentation or new documentation for new features.
- [ ] Refactoring: Non-functional changes that improve the codebase.
- [ ] Style: Non-functional changes related to code style (formatting, naming, etc).
- [ ] Testing: Additional tests to improve coverage or confirm functionality.
- [ ] Other: (Insert description of change)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All unit tests pass: `$ nox -s tests`
- [ ] The documentation builds: `$ nox -s doctest`

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:
- [ ] Code is well-commented, especially in complex or unclear areas.
- [ ] Added tests that prove my fix is effective or that my feature works.
- [ ] Checked that coverage remains or improves, and added tests if necessary to maintain or increase coverage.

Thank you for contributing to our project! Your efforts help us to deliver great software.
