### PR TITLE
Fixes for Failing Tests

### DIFF
--- a/tests/integration/test_monte_carlo_thevenin.py
+++ b/tests/integration/test_monte_carlo_thevenin.py
@@ -127,7 +127,7 @@ class TestSamplingThevenin:
         ],
     )
     def test_sampling_thevenin(self, sampler, posterior, map_estimate):
-        x0 = np.clip(map_estimate + np.random.normal(0, 1e-3, size=2), 1e-4, 1e-1)
+        x0 = np.clip(map_estimate + np.random.normal(0, 5e-4, size=2), 1e-4, 1e-1)
         common_args = {
             "log_pdf": posterior,
             "chains": 2,

--- a/tests/integration/test_monte_carlo_thevenin.py
+++ b/tests/integration/test_monte_carlo_thevenin.py
@@ -133,7 +133,7 @@ class TestSamplingThevenin:
             "chains": 2,
             "warm_up": 150,
             "cov0": [6e-3, 6e-3],
-            "max_iterations": 550,
+            "max_iterations": 1000 if sampler is SliceRankShrinkingMCMC else 550,
             "x0": x0,
         }
 


### PR DESCRIPTION
# Description

Reduces corruption in map estimate for monte carlo thevenin integration tests.

## Issue reference
Fixes # (issue-number)

## Review
Before you mark your PR as ready for review, please ensure that you've considered the following:
- Updated the [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) in reverse chronological order (newest at the top) with a concise description of the changes, including the PR number.
- Noted any breaking changes, including details on how it might impact existing functionality.

## Type of change
- [ ] New Feature: A non-breaking change that adds new functionality.
- [ ] Optimization: A code change that improves performance.
- [ ] Examples: A change to existing or additional examples.
- [ ] Bug Fix: A non-breaking change that addresses an issue.
- [ ] Documentation: Updates to documentation or new documentation for new features.
- [ ] Refactoring: Non-functional changes that improve the codebase.
- [ ] Style: Non-functional changes related to code style (formatting, naming, etc).
- [X] Testing: Additional tests to improve coverage or confirm functionality.
- [ ] Other: (Insert description of change)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All unit tests pass: `$ nox -s tests`
- [ ] The documentation builds: `$ nox -s doctest`

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:
- [ ] Code is well-commented, especially in complex or unclear areas.
- [ ] Added tests that prove my fix is effective or that my feature works.
- [ ] Checked that coverage remains or improves, and added tests if necessary to maintain or increase coverage.

Thank you for contributing to our project! Your efforts help us to deliver great software.
