### PR TITLE
Speed up iterative GITT method

### DIFF
--- a/examples/scripts/battery_parameterisation/gitt_pulse.py
+++ b/examples/scripts/battery_parameterisation/gitt_pulse.py
@@ -39,12 +39,8 @@ parameter_set = pybop.lithium_ion.SPDiffusion.apply_parameter_grouping(
 )
 
 # Fit the GITT pulse using the single particle diffusion model
-gitt_fit = pybop.GITTPulseFit(
-    gitt_pulse=dataset,
-    parameter_set=parameter_set,
-    electrode="positive",
-)
-gitt_results = gitt_fit()
+gitt_fit = pybop.GITTPulseFit(parameter_set=parameter_set, electrode="positive")
+gitt_results = gitt_fit(gitt_pulse=dataset)
 
 # Plot the timeseries output
 pybop.plot.problem(

--- a/pybop/models/lithium_ion/echem.py
+++ b/pybop/models/lithium_ion/echem.py
@@ -320,6 +320,24 @@ class SPDiffusion(EChemBaseModel):
             parameter_set=parameter_set, electrode=electrode
         )
 
+    def _set_initial_state(self, initial_state: dict, inputs=None):
+        """
+        Set the initial state of charge for the grouped SPMe. Inputs are not used.
+
+        Parameters
+        ----------
+        initial_state : dict
+            A valid initial state, e.g. the initial state of charge or open-circuit voltage.
+        inputs : Inputs, optional
+            The input parameters to be used when building the model.
+        """
+        if list(initial_state.keys()) != ["Initial stoichiometry"]:
+            raise ValueError(
+                "GroupedSPMe can currently only accept an initial stoichiometry."
+            )
+
+        self._unprocessed_parameter_set.update(initial_state)
+
 
 class GroupedSPMe(EChemBaseModel):
     """

--- a/tests/integration/test_applications.py
+++ b/tests/integration/test_applications.py
@@ -188,8 +188,8 @@ class TestApplications:
         )
         diffusion_time = parameter_set["Particle diffusion time scale [s]"]
 
-        gitt_fit = pybop.GITTPulseFit(pulse_data, parameter_set, electrode="positive")
-        gitt_results = gitt_fit()
+        gitt_fit = pybop.GITTPulseFit(parameter_set=parameter_set, electrode="positive")
+        gitt_results = gitt_fit(gitt_pulse=pulse_data)
 
         np.testing.assert_allclose(gitt_results.x[0], diffusion_time, rtol=5e-2)
 


### PR DESCRIPTION
# Description

Updates the GITT pulse fitting method to allow iteration over many pulses.

## Issue reference
Show feature

## Review
Before you mark your PR as ready for review, please ensure that you've considered the following:
- Updated the [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) in reverse chronological order (newest at the top) with a concise description of the changes, including the PR number.
- Noted any breaking changes, including details on how it might impact existing functionality.

## Type of change
- [ ] New Feature: A non-breaking change that adds new functionality.
- [ ] Optimization: A code change that improves performance.
- [ ] Examples: A change to existing or additional examples.
- [ ] Bug Fix: A non-breaking change that addresses an issue.
- [ ] Documentation: Updates to documentation or new documentation for new features.
- [ ] Refactoring: Non-functional changes that improve the codebase.
- [ ] Style: Non-functional changes related to code style (formatting, naming, etc).
- [ ] Testing: Additional tests to improve coverage or confirm functionality.
- [ ] Other: (Insert description of change)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All unit tests pass: `$ nox -s tests`
- [ ] The documentation builds: `$ nox -s doctest`

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:
- [ ] Code is well-commented, especially in complex or unclear areas.
- [ ] Added tests that prove my fix is effective or that my feature works.
- [ ] Checked that coverage remains or improves, and added tests if necessary to maintain or increase coverage.

Thank you for contributing to our project! Your efforts help us to deliver great software.
