### PR TITLE
fix tests failing with AttributeError: 'numpy.ndarray' object has no attribute 'toarray'

### DIFF
--- a/pybop/problems/fitting_problem.py
+++ b/pybop/problems/fitting_problem.py
@@ -197,7 +197,7 @@ class FittingProblem(BaseProblem):
                 {s: sol[s].data for s in self.output_variables},
                 {
                     p: {
-                        s: sol[s].sensitivities[p].toarray().reshape(-1)
+                        s: sol[s].sensitivities[p].reshape(-1)
                         for s in self.output_variables
                     }
                     for p in param_keys


### PR DESCRIPTION
# Description

Fixes tests failing with AttributeError: 'numpy.ndarray' object has no attribute 'toarray'

Fixes #810 

## Type of change

Bugfix

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `$ pre-commit run` or `$ nox -s pre-commit` (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctest`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
