### PR TITLE
Switch from macos-13 to macos-15-intel GitHub runner

### DIFF
--- a/.github/workflows/test_on_pull_request.yaml
+++ b/.github/workflows/test_on_pull_request.yaml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-15-intel, macos-14]
         python-version: ["3.10", "3.11", "3.12"]
         exclude: # We run the coverage tests on macos-14 with Python 3.12
           - os: macos-14


### PR DESCRIPTION
# Description

Ahead of the deprecation of the `macos-13` GitHub runner image, we can switch to `macos-15-intel` to keep running the unit tests on macOS with Intel CPU.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) to document the change (include PR #).

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `$ pre-commit run` or `$ nox -s pre-commit` (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctest`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
