### PR TITLE
Update scheduled workflow to macos-15-intel

### DIFF
--- a/scripts/ci/build_matrix.sh
+++ b/scripts/ci/build_matrix.sh
@@ -4,13 +4,13 @@
 # scheduled/nightly builds for PyBOP, i.e., in scheduled_tests.yaml
 # It generates a matrix of all combinations of the following variables:
 # - python_version: 3.X
-# - os: ubuntu-latest, windows-latest, macos-13 (amd64), macos-14 (arm64)
+# - os: ubuntu-latest, windows-latest, macos-15-intel (amd64), macos-14 (arm64)
 # - pybamm_version: the last X versions of PyBaMM from PyPI, excluding release candidates
 
 # To update the matrix, the variables below can be modified as needed.
 
 python_version=("3.10" "3.11" "3.12")
-os=("ubuntu-latest" "windows-latest" "macos-13" "macos-14")
+os=("ubuntu-latest" "windows-latest" "macos-15-intel" "macos-14")
 # This command fetches the last PyBaMM version excluding release candidates from PyPI
 pybamm_version=($(curl -s https://pypi.org/pypi/pybamm/json | jq -r '.releases | keys[]' | grep -v rc | sort -V | tail -n 1 | paste -sd " " -))
 


### PR DESCRIPTION
# Description

When updating the pull request workflow from the `macos-13` to the `macos-15-intel` GitHub runner, I missed that the same change is needed in the `build_matrix` for the scheduled workflow.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) to document the change (include PR #).

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `$ pre-commit run` or `$ nox -s pre-commit` (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctest`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
