### PR TITLE
Align PyBaMM simulation methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Breaking Changes
 
+- [#857](https://github.com/pybop-team/PyBOP/pull/857) - Deprecate the custom PyBaMM model build process for a simulation without an experiment and rename `batch_solve` as `solve_batch` to align with other functions.
 - [#839](https://github.com/pybop-team/PyBOP/pull/839) - Renames 'prior' as 'distribution' ``for pybop.Parameter``. Allows construction of a ``pybop.Parameter`` with a distribution of type ``scipy.stats.distributions.rv_frozen``. Removes ``margins``,  ``set_bounds``, ``remove_bounds`` from ``pybop.Parameter``.
 
 # [v25.11](https://github.com/pybop-team/PyBOP/tree/v25.11) - 2025-11-24

--- a/pybop/applications/base_method.py
+++ b/pybop/applications/base_method.py
@@ -132,7 +132,7 @@ class InverseOCV:
                 super().__init__(parameters=parameters)
                 self.ocv_value = ocv_value
 
-            def batch_solve(self, inputs, calculate_sensitivities: bool = False):
+            def solve_batch(self, inputs, calculate_sensitivities: bool = False):
                 solutions = []
                 for x in inputs:
                     diff = np.abs(ocv_function(x["Root"]) - self.ocv_value)

--- a/pybop/applications/ocp_methods.py
+++ b/pybop/applications/ocp_methods.py
@@ -182,7 +182,7 @@ class OCPAverage(BaseApplication):
 
             if self.allow_stretching:
 
-                def batch_solve(self, inputs, calculate_sensitivities: bool = False):
+                def solve_batch(self, inputs, calculate_sensitivities: bool = False):
                     solutions = []
                     for x in inputs:
                         sol = pybop.Solution()
@@ -203,7 +203,7 @@ class OCPAverage(BaseApplication):
                     return solutions
             else:
 
-                def batch_solve(self, inputs, calculate_sensitivities: bool = False):
+                def solve_batch(self, inputs, calculate_sensitivities: bool = False):
                     solutions = []
                     for x in inputs:
                         sol = pybop.Solution()
@@ -333,7 +333,7 @@ class OCPCapacityToStoichiometry(BaseApplication):
                 super().__init__(parameters=parameters)
                 self.domain_data = domain_data
 
-            def batch_solve(self, inputs, calculate_sensitivities: bool = False):
+            def solve_batch(self, inputs, calculate_sensitivities: bool = False):
                 solutions = []
                 for x in inputs:
                     sol = pybop.Solution()

--- a/pybop/problems/problem.py
+++ b/pybop/problems/problem.py
@@ -258,7 +258,7 @@ class Problem:
             the sensitivities dy/dx(t) for output variable(s) y, domain t and parameter(s) x.
         """
         model_inputs = [self.get_model_inputs(x) for x in inputs]
-        return self._simulator.batch_solve(
+        return self._simulator.solve_batch(
             inputs=model_inputs, calculate_sensitivities=calculate_sensitivities
         )
 

--- a/pybop/pybamm/eis_simulator.py
+++ b/pybop/pybamm/eis_simulator.py
@@ -256,7 +256,7 @@ class EISSimulator(BaseSimulator):
 
         return self._catch_errors(inputs)
 
-    def batch_solve(
+    def solve_batch(
         self, inputs: "list[Inputs]" = None, calculate_sensitivities: bool = False
     ) -> list[Solution | FailedSolution]:
         """

--- a/pybop/pybamm/eis_simulator.py
+++ b/pybop/pybamm/eis_simulator.py
@@ -100,7 +100,6 @@ class EISSimulator(BaseSimulator):
             discretisation_kwargs=discretisation_kwargs,
             build_every_time=build_every_time,
         )
-
         self.debug_mode = False
 
         # Initialise
@@ -289,9 +288,7 @@ class EISSimulator(BaseSimulator):
             for x in inputs:
                 try:
                     simulations.append(self._solve(x))
-                except (ZeroDivisionError, RuntimeError, ValueError) as e:
-                    if isinstance(e, ValueError) and str(e) not in self.exception:
-                        raise  # Raise the error if it doesn't match the expected list
+                except (ZeroDivisionError, RuntimeError, ValueError):
                     simulations.append(
                         FailedSolution(["Impedance"], [k for k in x.keys()])
                     )
@@ -372,8 +369,13 @@ class EISSimulator(BaseSimulator):
         return False
 
     @property
-    def exception(self):
-        return self._simulator.exception
+    def debug_mode(self):
+        return self._debug_mode
+
+    @debug_mode.setter
+    def debug_mode(self, value: bool):
+        self._debug_mode = value
+        self._simulator.debug_mode = value
 
     def copy(self):
         """Return a copy of the simulation."""

--- a/pybop/pybamm/eis_simulator.py
+++ b/pybop/pybamm/eis_simulator.py
@@ -88,7 +88,7 @@ class EISSimulator(BaseSimulator):
         super().__init__(parameters=parameters)
 
         # Set up a simulation
-        self._simulation = Simulator(
+        self._simulator = Simulator(
             model,
             parameter_values=parameter_values,
             initial_state=initial_state,
@@ -110,7 +110,7 @@ class EISSimulator(BaseSimulator):
 
         v_scale = getattr(model.variables["Voltage [V]"], "scale", 1)
         i_scale = getattr(model.variables["Current [A]"], "scale", 1)
-        self.z_scale = self._simulation.parameter_values.evaluate(v_scale / i_scale)
+        self.z_scale = self.parameter_values.evaluate(v_scale / i_scale)
 
     def set_up_for_eis(self, model: pybamm.BaseModel) -> pybamm.BaseModel:
         """
@@ -184,8 +184,10 @@ class EISSimulator(BaseSimulator):
 
     def _model_rebuild(self, inputs: "Inputs") -> None:
         """Update the parameter values and rebuild the EIS model."""
-        if self._simulation.requires_model_rebuild:
-            self._simulation.rebuild_model(inputs=inputs)
+        if self._simulator.requires_model_rebuild:
+            self.parameter_values.update(inputs)
+            self._simulator.create_simulation()
+            self.simulation.build(initial_soc=self._simulator.initial_state)
         self._initialise_eis_matrices(inputs=inputs)
 
     def _initialise_eis_matrices(self, inputs: "Inputs") -> None:
@@ -199,9 +201,9 @@ class EISSimulator(BaseSimulator):
         RuntimeError
             If the model hasn't been built yet.
         """
-        built_model = self._simulation.built_model
-        M = self._simulation.built_model.mass_matrix.entries
-        self._simulation.solver.set_up(built_model, inputs=inputs)
+        built_model = self.simulation.built_model
+        M = built_model.mass_matrix.entries
+        self.simulation.solver.set_up(built_model, inputs=inputs)
 
         # Convert inputs to casadi format if needed
         casadi_inputs = (
@@ -355,19 +357,23 @@ class EISSimulator(BaseSimulator):
 
     @property
     def simulation(self):
-        return self._simulation
+        return self._simulator._simulation  # noqa: SLF001
 
     @property
     def parameter_values(self):
-        return self._simulation.parameter_values
+        return self._simulator.parameter_values
 
     @property
     def input_parameter_names(self):
-        return self._simulation.input_parameter_names
+        return self._simulator.input_parameter_names
 
     @property
     def has_sensitivities(self):
         return False
+
+    @property
+    def exception(self):
+        return self._simulator.exception
 
     def copy(self):
         """Return a copy of the simulation."""

--- a/pybop/pybamm/simulator.py
+++ b/pybop/pybamm/simulator.py
@@ -87,6 +87,7 @@ class Simulator(BaseSimulator):
         for name, param in parameter_values.items():
             if isinstance(param, Parameter):
                 parameters.add(name, param)
+                self._parameter_values.update({name: "[input]"})
             elif isinstance(param, pybamm.InputParameter):
                 parameters.add(name, Parameter())
         super().__init__(parameters=parameters)
@@ -129,10 +130,8 @@ class Simulator(BaseSimulator):
         self.verbose = False
 
         # State
-        self._built_model = None
-        self._sim_experiment = None
+        self._simulation = None
         self._solve = None
-        self._calculate_sensitivities = False
 
         # Build
         self._input_parameter_names = self.parameters.names
@@ -199,21 +198,18 @@ class Simulator(BaseSimulator):
         if self._experiment is None and self._initial_state is not None:
             return True
 
-        # Test whether the model needs rebuilding by marking parameters as inputs
-        unmodified_parameter_values = self._parameter_values.copy()
-        for param in self._input_parameter_names:
-            self._parameter_values.update({param: "[input]"})
-
-        # If the model builds successfully with inputs, it does not need rebuilding
+        # If the model builds successfully with empty inputs, it does not need rebuilding
         try:
-            self.build_model()
+            self.create_simulation()
+            self._simulation.build(initial_soc=self._initial_state, inputs=None)
             requires_model_rebuild = False
         except (ValueError, TypeError, IndexError):
-            self._built_model = None
             requires_model_rebuild = True
 
+        # Reset
+        self._simulation = None
+
         if requires_model_rebuild or build_every_time:
-            self._parameter_values = unmodified_parameter_values  # reset
             return True
         return False
 
@@ -257,24 +253,18 @@ class Simulator(BaseSimulator):
         # Speed up the solver with output_variables if provided
         self._solver.output_variables = output_variables or []
 
-        if self._experiment is not None:
-            # Build if only building once, otherwise build on evalution
-            if not self._requires_model_rebuild:
-                self._sim_experiment = self._create_experiment_simulation()
-                self._solve = self._simulate_experiment_without_rebuild
-            else:
-                self._solve = self._simulate_experiment_with_rebuild
-
-        else:
-            # Remove all voltage-based events when not using an experiment
+        # Remove all voltage-based events when not using an experiment
+        if self._experiment is None:
             self._model.events = [e for e in self._model.events if "[V]" not in e.name]
 
-            # Build if only building once, otherwise build on evalution
-            if not self._requires_model_rebuild:
-                self.build_model()
-                self._solve = self._solve_in_time_without_rebuild
-            else:
-                self._solve = self._solve_in_time_with_rebuild
+        # Build if only building once, otherwise build on evaluation
+        if not self._requires_model_rebuild:
+            self.create_simulation()
+            if self._experiment is None:
+                self._simulation.build(initial_soc=self._initial_state)
+            self._solve = self._simulate_without_rebuild
+        else:
+            self._solve = self._simulate_with_rebuild
 
     def solve(
         self,
@@ -339,12 +329,19 @@ class Simulator(BaseSimulator):
         # Set whether to compute the sensitivities
         if calculate_sensitivities and not self.has_sensitivities:
             raise ValueError("Sensitivities are not available.")
-        self._calculate_sensitivities = calculate_sensitivities
 
-        # The underlying solve method is one of four methods set during initialisation
-        return self._process_solutions(self._catch_errors(inputs))
+        # Gather solve options
+        options = {
+            "initial_soc": self._initial_state,
+            "calculate_sensitivities": calculate_sensitivities,
+        }
+        if self._experiment is None:
+            options.update({"t_eval": self._t_eval, "t_interp": self._t_interp})
 
-    def _catch_errors(self, inputs: "list[Inputs]"):
+        # The underlying solve method is one of two methods set during initialisation
+        return self._process_solutions(self._catch_errors(inputs, options))
+
+    def _catch_errors(self, inputs: "list[Inputs]", options: dict):
         if not self.debug_mode:
             try:
                 with warnings.catch_warnings():
@@ -352,7 +349,7 @@ class Simulator(BaseSimulator):
                         warnings.filterwarnings(
                             "error", category=UserWarning, message=pattern
                         )
-                    return self._solve(inputs)
+                    return self._solve(inputs, options)
 
             except (
                 SolverError,
@@ -371,7 +368,7 @@ class Simulator(BaseSimulator):
                     solutions = []
                     for x in inputs:
                         try:
-                            solutions += self._solve([x])
+                            solutions += self._solve([x], options)
                         except (
                             SolverError,
                             ZeroDivisionError,
@@ -398,117 +395,47 @@ class Simulator(BaseSimulator):
                             )
                     return solutions
 
-        return self._solve(inputs)
+        return self._solve(inputs, options)
 
-    """ ______ ______ ATTRIBUTES FOR SOLVING IN TIME, WITHOUT AN EXPERIMENT ______ ______  """
-
-    def rebuild_model(self, inputs: "Inputs") -> None:
-        """Update the parameter values and rebuild the model, if required."""
-        if not self._requires_model_rebuild:
-            # Parameter values will be passed to the solver as inputs
-            return
-
-        # Update the parameter values and build again
-        self._parameter_values.update(inputs)
-        self.build_model()
-
-    def build_model(self) -> None:
-        """Build the model using the given parameter values."""
-        # Build pybamm model if not already built
-        if not self._model.built:
-            self._model.build_model()
-
-        model = self._model.new_copy()
-        geometry = deepcopy(self._geometry)
-
-        if self._experiment is None and self._initial_state is not None:
-            self._parameter_values.set_initial_state(
-                self._initial_state, param=model.param, options=model.options
-            )
-
-        self._parameter_values.process_geometry(geometry)
-        self._parameter_values.process_model(model)
-
-        mesh = pybamm.Mesh(geometry, self._submesh_types, self._var_pts)
-        disc = pybamm.Discretisation(
-            mesh, self._spatial_methods, **self._discretisation_kwargs
-        )
-        disc.process_model(model)
-
-        self._built_model = model
-        self._solver = self._solver.copy()  # reset solver for new model
-
-    def _solve_in_time_without_rebuild(
-        self, inputs: "list[Inputs]"
-    ) -> list[pybamm.Solution]:
-        """Solve in time without rebuilding the PyBaMM model."""
-        if len(inputs) == 1:
-            solutions = [self._pybamm_solve(inputs=inputs[0])]
-        else:
-            solutions = self._pybamm_solve(inputs=inputs)
-        return solutions
-
-    def _solve_in_time_with_rebuild(
-        self, inputs: "list[Inputs]"
-    ) -> list[pybamm.Solution]:
-        """Solve in time, rebuilding the model for each set of inputs."""
-        solutions = []
-        for x in inputs:
-            self.rebuild_model(x)
-            solutions.append(self._pybamm_solve(inputs=None))
-        return solutions
-
-    def _pybamm_solve(
-        self, inputs: "Inputs | list[Inputs] | None"
-    ) -> pybamm.Solution | list[pybamm.Solution]:
-        """A function that runs the simulation using the built model."""
-        return self._solver.solve(
-            model=self._built_model,
-            inputs=inputs,
-            t_eval=self._t_eval,
-            t_interp=self._t_interp,
-            calculate_sensitivities=self._calculate_sensitivities,
-        )
-
-    """ ______ ______ ______ ATTRIBUTES FOR SIMULATING AN EXPERIMENT ______ ______ ______  """
-
-    def _create_experiment_simulation(self) -> pybamm.Simulation:
-        """Create a simulation with current configuration and an experiment."""
-        return pybamm.Simulation(
-            self._model,
+    def create_simulation(self) -> pybamm.Simulation:
+        """Create a simulation with current configuration and optional experiment."""
+        self._simulation = pybamm.Simulation(
+            self._model.new_copy(),
             parameter_values=self._parameter_values,
             experiment=self._experiment,
-            solver=self._solver,
-            geometry=self._geometry,
+            solver=self._solver.copy(),
+            geometry=deepcopy(self._geometry),
             submesh_types=self._submesh_types,
             var_pts=self._var_pts,
             spatial_methods=self._spatial_methods,
             discretisation_kwargs=self._discretisation_kwargs,
         )
 
-    def _simulate_experiment_without_rebuild(
-        self, inputs: "list[Inputs]"
+    def _simulate_without_rebuild(
+        self, inputs: "list[Inputs]", options: dict
     ) -> list[pybamm.Solution]:
-        """Simulate an experiment without rebuilding the PyBaMM model."""
-        solutions = []
-        for x in inputs:
-            sol = self._sim_experiment.solve(inputs=x, initial_soc=self._initial_state)
-            solutions.append(sol)
-        return solutions
+        """Simulate without rebuilding the PyBaMM model."""
+        if len(inputs) == 1:
+            return [self._simulation.solve(inputs=inputs[0], **options)]
 
-    def _simulate_experiment_with_rebuild(
-        self, inputs: "list[Inputs]"
+        return self._simulation.solve(inputs=inputs, **options)
+
+    def _simulate_with_rebuild(
+        self, inputs: "list[Inputs]", options: dict
     ) -> list[pybamm.Solution]:
-        """Simulate an experiment, rebuilding the simulation for each set of inputs."""
+        """Simulate, rebuilding the simulation for each set of inputs."""
+        unmodified_parameter_values = self._parameter_values.copy()
+
         solutions = []
         for x in inputs:
             # Update parameters and create new simulation
             self._parameter_values.update(x)
-            sim = self._create_experiment_simulation()
-            solutions.append(sim.solve(initial_soc=self._initial_state))
-        return solutions
+            self.create_simulation()
+            solutions.append(self._simulation.solve(**options))
 
-    """ ______ ______ ______ ______ GENERAL ATTRIBUTES ______ ______ ______ ______ ______  """
+        self._simulation = None
+        self._parameter_values = unmodified_parameter_values
+        return solutions
 
     def _process_solutions(
         self, solutions: list[pybamm.Solution]
@@ -527,7 +454,7 @@ class Simulator(BaseSimulator):
 
     @property
     def built_model(self):
-        return self._built_model
+        return None if self._simulation is None else self._simulation._built_model  # noqa: SLF001
 
     @property
     def input_parameter_names(self):
@@ -559,8 +486,7 @@ class Simulator(BaseSimulator):
 
     def set_output_variables(self, value: list[str] | None):
         self._output_variables = value
-        if self.experiment is None:
-            self._set_up_solution_method(output_variables=value)
+        self._set_up_solution_method(output_variables=value)
 
     @property
     def requires_model_rebuild(self):

--- a/pybop/pybamm/simulator.py
+++ b/pybop/pybamm/simulator.py
@@ -1,4 +1,3 @@
-import warnings
 from copy import copy, deepcopy
 from typing import TYPE_CHECKING
 
@@ -118,20 +117,11 @@ class Simulator(BaseSimulator):
         self._spatial_methods = spatial_methods or model.default_spatial_methods
         self._discretisation_kwargs = discretisation_kwargs or {"check_model": True}
 
-        # Warnings
-        self.exception = [
-            "These parameter values are infeasible."
-        ]  # TODO: Update to a utility function and add to it on exception creation
-        self.warning_patterns = [
-            "Ah is greater than",
-            "Non-physical point encountered",
-        ]
-        self.debug_mode = False
-        self.verbose = False
-
         # State
         self._simulation = None
         self._solve = None
+        self.debug_mode = False
+        self.verbose = False
 
         # Build
         self._input_parameter_names = self.parameters.names
@@ -249,12 +239,11 @@ class Simulator(BaseSimulator):
         self, output_variables: list[str] | None = None
     ) -> None:
         """Configure the mode of operation."""
-
-        # Speed up the solver with output_variables if provided
-        self._solver.output_variables = output_variables or []
-
-        # Remove all voltage-based events when not using an experiment
         if self._experiment is None:
+            # Speed up the solver with output_variables if provided
+            self._solver.output_variables = output_variables or []
+
+            # Remove all voltage-based events when not using an experiment
             self._model.events = [e for e in self._model.events if "[V]" not in e.name]
 
         # Build if only building once, otherwise build on evaluation
@@ -344,56 +333,35 @@ class Simulator(BaseSimulator):
     def _catch_errors(self, inputs: "list[Inputs]", options: dict):
         if not self.debug_mode:
             try:
-                with warnings.catch_warnings():
-                    for pattern in self.warning_patterns:
-                        warnings.filterwarnings(
-                            "error", category=UserWarning, message=pattern
-                        )
-                    return self._solve(inputs, options)
+                return self._solve(inputs, options)
 
             except (
                 SolverError,
                 ZeroDivisionError,
                 RuntimeError,
                 ValueError,
-                UserWarning,
                 Exception,
             ):
                 # Try separately
-                with warnings.catch_warnings():
-                    for pattern in self.warning_patterns:
-                        warnings.filterwarnings(
-                            "error", category=UserWarning, message=pattern
+                solutions = []
+                for x in inputs:
+                    try:
+                        solutions += self._solve([x], options)
+                    except (
+                        SolverError,
+                        ZeroDivisionError,
+                        RuntimeError,
+                        ValueError,
+                        Exception,
+                    ) as e:
+                        if self.verbose:
+                            print(f"Ignoring this sample due to: {e}")
+                        solutions.append(
+                            FailedSolution(
+                                self.output_variables, self._input_parameter_names
+                            )
                         )
-                    solutions = []
-                    for x in inputs:
-                        try:
-                            solutions += self._solve([x], options)
-                        except (
-                            SolverError,
-                            ZeroDivisionError,
-                            RuntimeError,
-                            ValueError,
-                        ) as e:
-                            if (
-                                isinstance(e, ValueError)
-                                and str(e) not in self.exception
-                            ):
-                                raise  # Raise the error if it doesn't match the expected list
-                            solutions.append(
-                                FailedSolution(
-                                    self.output_variables, self._input_parameter_names
-                                )
-                            )
-                        except (UserWarning, Exception) as e:
-                            if self.verbose:
-                                print(f"Ignoring this sample due to: {e}")
-                            solutions.append(
-                                FailedSolution(
-                                    self.output_variables, self._input_parameter_names
-                                )
-                            )
-                    return solutions
+                return solutions
 
         return self._solve(inputs, options)
 
@@ -486,7 +454,8 @@ class Simulator(BaseSimulator):
 
     def set_output_variables(self, value: list[str] | None):
         self._output_variables = value
-        self._set_up_solution_method(output_variables=value)
+        if self.experiment is None:
+            self._set_up_solution_method(output_variables=value)
 
     @property
     def requires_model_rebuild(self):

--- a/pybop/pybamm/simulator.py
+++ b/pybop/pybamm/simulator.py
@@ -184,10 +184,6 @@ class Simulator(BaseSimulator):
         if not self._input_parameter_names:
             return False
 
-        # All non-experiment protocols with an initial state require model rebuilding
-        if self._experiment is None and self._initial_state is not None:
-            return True
-
         # If the model builds successfully with empty inputs, it does not need rebuilding
         try:
             self.create_simulation()

--- a/pybop/pybamm/simulator.py
+++ b/pybop/pybamm/simulator.py
@@ -290,11 +290,11 @@ class Simulator(BaseSimulator):
         # Convert and standardise inputs as a list of candidate dictionaries
         inputs = inputs or {}
         if not isinstance(inputs, list):
-            return self.batch_solve([inputs], calculate_sensitivities)[0]
+            return self.solve_batch([inputs], calculate_sensitivities)[0]
 
-        return self.batch_solve(inputs, calculate_sensitivities)
+        return self.solve_batch(inputs, calculate_sensitivities)
 
-    def batch_solve(
+    def solve_batch(
         self,
         inputs: "list[Inputs]",
         calculate_sensitivities: bool = False,

--- a/pybop/simulators/base_simulator.py
+++ b/pybop/simulators/base_simulator.py
@@ -43,15 +43,15 @@ class BaseSimulator:
         calculate_sensitivities=True.
         """
         if not isinstance(inputs, list):
-            return self.batch_solve(
+            return self.solve_batch(
                 inputs=[inputs], calculate_sensitivities=calculate_sensitivities
             )[0]
 
-        return self.batch_solve(
+        return self.solve_batch(
             inputs=inputs, calculate_sensitivities=calculate_sensitivities
         )
 
-    def batch_solve(
+    def solve_batch(
         self,
         inputs: "list[Inputs]",
         calculate_sensitivities: bool = False,


### PR DESCRIPTION
# Description

Remove the custom build process for PyBaMM simulations without an experimental protocol. The aim is to improve maintainability by always using the build process provided by PyBaMM's Simulation class.

Also, change `batch_solve` to `solve_batch` to align with other function names such as `evaluate_batch`. Deprecate some of the warning/error catches that no longer appear to be needed.

Fixes #783 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) to document the change (include PR #).

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `$ pre-commit run` or `$ nox -s pre-commit` (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctest`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
