### PR TITLE
Open issues if PyBaMM dev and lowest-dependency tests fail

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Build draft PDF
         uses: openjournals/openjournals-draft-action@85a18372e48f551d8af9ddb7a747de685fbbb01c # v1.0
         with:

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -14,15 +14,15 @@ jobs:
     name: Paper Draft
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build draft PDF
-        uses: openjournals/openjournals-draft-action@master
+        uses: openjournals/openjournals-draft-action@85a18372e48f551d8af9ddb7a747de685fbbb01c # v1.0
         with:
           journal: joss
           # This should be the path to the paper within your repo.
           paper-path: papers/joss/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled

--- a/.github/workflows/lychee_links.yaml
+++ b/.github/workflows/lychee_links.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Restore lychee cache
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/lychee_links.yaml
+++ b/.github/workflows/lychee_links.yaml
@@ -15,17 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Restore lychee cache
-        uses: actions/cache@v4
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
           restore-keys: cache-lychee-
 
       - name: Run lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2.7.0
         with:
           args: >-
             --cache

--- a/.github/workflows/nightly_dependency_tests.yaml
+++ b/.github/workflows/nightly_dependency_tests.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.12"]
         suite: ["unit", "integration", "examples", "notebooks"]
 

--- a/.github/workflows/nightly_dependency_tests.yaml
+++ b/.github/workflows/nightly_dependency_tests.yaml
@@ -17,103 +17,72 @@ concurrency:
 permissions: {}
 
 jobs:
-  check_latest_dependencies:
+  check_dependencies:
+    name: Test-${{ matrix.dep-type }}-${{ matrix.os }}-py-${{ matrix.python-version }}-${{ matrix.suite }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.12"]
         suite: ["unit", "integration", "examples", "notebooks"]
+        dep-type: ["latest", "lowest"]
+        include:
+          - dep-type: latest
+            python-version: "3.13"
+          - dep-type: lowest
+            python-version: "3.10"
     permissions:
       contents: read
       issues: write # for creating issues when tests fail
-
-    name: Test-latest-${{ matrix.os }}-py-${{ matrix.python-version }}-${{ matrix.suite }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install -e .[all,dev]
-          python -m pip uninstall -y pybamm
-          python -m pip install "pybamm[all] @ git+https://github.com/pybamm-team/PyBaMM@main"
-          python -m pip install pytest-reportlog
 
-      - name: Run ${{ matrix.suite }} tests
-        id: pytest-latest
-        run: |
-          if [[ "${{ matrix.suite }}" == "unit" ]]; then
-              python -m pytest --unit --report-log=pytest-log.jsonl
-          elif [[ "${{ matrix.suite }}" == "integration" ]]; then
-              python -m pytest --integration --report-log=pytest-log.jsonl
-          elif [[ "${{ matrix.suite }}" == "examples" ]]; then
-              python -m pytest --examples --report-log=pytest-log.jsonl
-          elif [[ "${{ matrix.suite }}" == "notebooks" ]]; then
-              python -m pytest --notebooks --nbmake --nbmake-timeout=1000 examples/ --report-log=pytest-log.jsonl
-          fi
-
-      - name: Create issues from pytest logs
-        uses: scientific-python/issue-from-pytest-log-action@558a3dfdd251069b328d3fded994824ddbefc47b # v1.4.0
-        if: |
-          failure()
-          && steps.pytest-latest.outcome == 'failure'
-          && github.repository == 'pybop-team/PyBOP'
-          && github.event_name == 'schedule'
-        with:
-          log-path: pytest-log.jsonl
-          issue-title: "Nightly latest dependencies ${{ matrix.suite }} tests failed for ${{ matrix.os }} Python ${{ matrix.python-version }}"
-
-  check_lowest_dependencies:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10"]
-        suite: ["unit", "integration", "examples", "notebooks"]
-    permissions:
-      contents: read
-      issues: write # for creating issues when tests fail
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: "true"
-      - name: Install dependencies
+
+      - name: Install dependencies (latest)
+        if: matrix.dep-type == 'latest'
+        run: |
+          uv pip install -e .[all,dev]
+          uv pip uninstall -y pybamm
+          uv pip install "pybamm[all] @ git+https://github.com/pybamm-team/PyBaMM@main"
+          uv pip install pytest-reportlog
+
+      - name: Install dependencies (lowest)
+        if: matrix.dep-type == 'lowest'
         run: |
           uv pip install -e .[dev]
           uv pip install --resolution lowest-direct -e .[all]
           uv pip install pytest-reportlog
 
       - name: Run ${{ matrix.suite }} tests
-        id: pytest-lowest
+        id: pytest
+        env:
+          PYTEST: "pytest --report-log=pytest-log.jsonl"
         run: |
           if [[ "${{ matrix.suite }}" == "unit" ]]; then
-              python -m pytest --unit --report-log=pytest-log.jsonl
+              python -m $PYTEST --unit
           elif [[ "${{ matrix.suite }}" == "integration" ]]; then
-              python -m pytest --integration --report-log=pytest-log.jsonl
+              python -m $PYTEST --integration
           elif [[ "${{ matrix.suite }}" == "examples" ]]; then
-              python -m pytest --examples --report-log=pytest-log.jsonl
+              python -m $PYTEST --examples
           elif [[ "${{ matrix.suite }}" == "notebooks" ]]; then
-              python -m pytest --notebooks --nbmake --nbmake-timeout=1000 examples/ --report-log=pytest-log.jsonl
+              python -m $PYTEST --notebooks --nbmake --nbmake-timeout=1000 examples/
           fi
 
       - name: Create issues from pytest logs
         uses: scientific-python/issue-from-pytest-log-action@558a3dfdd251069b328d3fded994824ddbefc47b # v1.4.0
         if: |
           failure()
-          && steps.pytest-lowest.outcome == 'failure'
+          && steps.pytest.outcome == 'failure'
           && github.repository == 'pybop-team/PyBOP'
           && github.event_name == 'schedule'
         with:
           log-path: pytest-log.jsonl
-          issue-title: "Nightly lowest dependencies ${{ matrix.suite }} tests failed for ${{ matrix.os }} Python ${{ matrix.python-version }}"
+          issue-title: "Nightly ${{ matrix.dep-type }} dependencies ${{ matrix.suite }} tests failed (${{ matrix.os }} Python ${{ matrix.python-version }})"

--- a/.github/workflows/nightly_dependency_tests.yaml
+++ b/.github/workflows/nightly_dependency_tests.yaml
@@ -14,6 +14,8 @@ concurrency:
   # Cancel in-progress runs when a new workflow with the same group name is triggered
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   check_latest_dependencies:
     runs-on: ${{ matrix.os }}
@@ -23,8 +25,11 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.12"]
         suite: ["unit", "integration", "examples", "notebooks"]
+    permissions:
+      contents: read
+      issues: write # for creating issues when tests fail
 
-    name: Test-${{ matrix.os }}-py-${{ matrix.python-version }}-${{ matrix.suite }})
+    name: Test-latest-${{ matrix.os }}-py-${{ matrix.python-version }}-${{ matrix.suite }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,31 +44,43 @@ jobs:
           python -m pip install -e .[all,dev]
           python -m pip uninstall -y pybamm
           python -m pip install "pybamm[all] @ git+https://github.com/pybamm-team/PyBaMM@main"
-
+          python -m pip install pytest-reportlog
 
       - name: Run ${{ matrix.suite }} tests
+        id: pytest-latest
         run: |
           if [[ "${{ matrix.suite }}" == "unit" ]]; then
-              python -m pytest --unit
+              python -m pytest --unit --report-log=pytest-log.jsonl
           elif [[ "${{ matrix.suite }}" == "integration" ]]; then
-              python -m pytest --integration
+              python -m pytest --integration --report-log=pytest-log.jsonl
           elif [[ "${{ matrix.suite }}" == "examples" ]]; then
-              python -m pytest --examples
+              python -m pytest --examples --report-log=pytest-log.jsonl
           elif [[ "${{ matrix.suite }}" == "notebooks" ]]; then
-              python -m pytest --notebooks --nbmake --nbmake-timeout=1000 examples/
+              python -m pytest --notebooks --nbmake --nbmake-timeout=1000 examples/ --report-log=pytest-log.jsonl
           fi
+
+      - name: Create issues from pytest logs
+        uses: scientific-python/issue-from-pytest-log-action@558a3dfdd251069b328d3fded994824ddbefc47b # v1.4.0
+        if: |
+          failure()
+          && steps.pytest-latest.outcome == 'failure'
+          && github.repository == 'pybop-team/PyBOP'
+          && github.event_name == 'schedule'
+        with:
+          log-path: pytest-log.jsonl
+          issue-title: "Nightly latest dependencies ${{ matrix.suite }} tests failed for ${{ matrix.os }} Python ${{ matrix.python-version }}"
 
   check_lowest_dependencies:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.10"]
         suite: ["unit", "integration", "examples", "notebooks"]
-
-    name: Test-${{ matrix.os }}-py-${{ matrix.python-version }}-${{ matrix.suite }})
-
+    permissions:
+      contents: read
+      issues: write # for creating issues when tests fail
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
@@ -75,16 +92,28 @@ jobs:
         run: |
           uv pip install -e .[dev]
           uv pip install --resolution lowest-direct -e .[all]
-
+          uv pip install pytest-reportlog
 
       - name: Run ${{ matrix.suite }} tests
+        id: pytest-lowest
         run: |
           if [[ "${{ matrix.suite }}" == "unit" ]]; then
-              python -m pytest --unit
+              python -m pytest --unit --report-log=pytest-log.jsonl
           elif [[ "${{ matrix.suite }}" == "integration" ]]; then
-              python -m pytest --integration
+              python -m pytest --integration --report-log=pytest-log.jsonl
           elif [[ "${{ matrix.suite }}" == "examples" ]]; then
-              python -m pytest --examples
+              python -m pytest --examples --report-log=pytest-log.jsonl
           elif [[ "${{ matrix.suite }}" == "notebooks" ]]; then
-              python -m pytest --notebooks --nbmake --nbmake-timeout=1000 examples/
+              python -m pytest --notebooks --nbmake --nbmake-timeout=1000 examples/ --report-log=pytest-log.jsonl
           fi
+
+      - name: Create issues from pytest logs
+        uses: scientific-python/issue-from-pytest-log-action@558a3dfdd251069b328d3fded994824ddbefc47b # v1.4.0
+        if: |
+          failure()
+          && steps.pytest-lowest.outcome == 'failure'
+          && github.repository == 'pybop-team/PyBOP'
+          && github.event_name == 'schedule'
+        with:
+          log-path: pytest-log.jsonl
+          issue-title: "Nightly lowest dependencies ${{ matrix.suite }} tests failed for ${{ matrix.os }} Python ${{ matrix.python-version }}"

--- a/.github/workflows/nightly_dependency_tests.yaml
+++ b/.github/workflows/nightly_dependency_tests.yaml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/nightly_dependency_tests.yaml
+++ b/.github/workflows/nightly_dependency_tests.yaml
@@ -27,9 +27,9 @@ jobs:
     name: Test-${{ matrix.os }}-py-${{ matrix.python-version }}-${{ matrix.suite }})
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -63,9 +63,9 @@ jobs:
     name: Test-${{ matrix.os }}-py-${{ matrix.python-version }}-${{ matrix.suite }})
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: "true"

--- a/.github/workflows/nightly_dependency_tests.yaml
+++ b/.github/workflows/nightly_dependency_tests.yaml
@@ -26,9 +26,12 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         suite: ["unit", "integration", "examples", "notebooks"]
         dep-type: ["latest", "lowest"]
+        # The following must remain in sync with our Python version support as defined in pyproject.toml
         include:
+          # Latest dependencies with Python 3.13 (our maximum supported Python version)
           - dep-type: latest
             python-version: "3.13"
+          # Lowest dependencies with Python 3.10 (our minimum supported Python version)
           - dep-type: lowest
             python-version: "3.10"
     permissions:

--- a/.github/workflows/periodic_benchmarks.yaml
+++ b/.github/workflows/periodic_benchmarks.yaml
@@ -28,6 +28,8 @@ jobs:
           rm -rf ./.??* || true
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install python & create virtualenv
         shell: bash

--- a/.github/workflows/periodic_benchmarks.yaml
+++ b/.github/workflows/periodic_benchmarks.yaml
@@ -27,7 +27,7 @@ jobs:
           rm -rf ./* || true
           rm -rf ./.??* || true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install python & create virtualenv
         shell: bash
@@ -47,7 +47,7 @@ jobs:
             python -m asv run --machine "SelfHostedRunner" NEW --show-stderr -v
 
       - name: Upload results as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: asv_periodic_results
           path: results
@@ -67,7 +67,7 @@ jobs:
     if: github.repository == 'pybop-team/PyBOP'
     steps:
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.12
 
@@ -75,13 +75,13 @@ jobs:
         run: pip install asv
 
       - name: Checkout pybop-bench repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: pybop-team/pybop-bench
           token: ${{ secrets.PUSH_BENCH_TOKEN }}
 
       - name: Download results artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: asv_periodic_results
           path: new_results

--- a/.github/workflows/release_action.yaml
+++ b/.github/workflows/release_action.yaml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:

--- a/.github/workflows/release_action.yaml
+++ b/.github/workflows/release_action.yaml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.12"
     - name: Build a source tarball and a wheel from it
       run: pipx run build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: python-package-distributions
         path: dist/
@@ -40,13 +40,13 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: python-package-distributions
         path: dist/
         merge-multiple: true
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
 
   github-release:
     name: >-
@@ -62,19 +62,19 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: python-package-distributions
         path: dist/
         merge-multiple: true
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      uses: sigstore/gh-action-sigstore-python@a5caf349bc536fbef3668a10ed7f5cd309a4b53d # v3.2.0
       with:
         inputs: >-
           ./dist/*.tar.gz
           ./dist/*.whl
     - name: Publish artifacts and signatures to GitHub Releases
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
       with:
         # `dist/` contains the built packages, and the
         # sigstore-produced signatures and certificates.
@@ -97,12 +97,12 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: python-package-distributions
         path: dist/
         merge-multiple: true
     - name: Publish distribution 📦 to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/scheduled_tests.yaml
+++ b/.github/workflows/scheduled_tests.yaml
@@ -24,6 +24,7 @@ jobs:
       - name: Check out PyBOP repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             scripts/ci/build_matrix.sh
@@ -83,6 +84,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python_version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -126,6 +129,9 @@ jobs:
           rm -rf ./.??* || true
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Install python & create virtualenv
         shell: bash
         run: |

--- a/.github/workflows/scheduled_tests.yaml
+++ b/.github/workflows/scheduled_tests.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out PyBOP repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
@@ -82,9 +82,9 @@ jobs:
       PYBAMM_VERSION: ${{ matrix.pybamm_version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python_version }}
 
@@ -125,7 +125,7 @@ jobs:
           rm -rf ./* || true
           rm -rf ./.??* || true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install python & create virtualenv
         shell: bash
         run: |

--- a/.github/workflows/test_on_pull_request.yaml
+++ b/.github/workflows/test_on_pull_request.yaml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -44,6 +47,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -72,6 +78,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -97,6 +106,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -122,6 +134,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -147,6 +162,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Set up Python 3.12
         id: setup-python
@@ -176,6 +192,9 @@ jobs:
     steps:
       - name: Check out PyBOP repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Set up Python 3.12
         id: setup-python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/test_on_pull_request.yaml
+++ b/.github/workflows/test_on_pull_request.yaml
@@ -20,9 +20,9 @@ jobs:
   style:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.11
 
@@ -43,9 +43,9 @@ jobs:
     name: Integration tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -71,9 +71,9 @@ jobs:
     name: Unit tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -96,9 +96,9 @@ jobs:
     name: Test examples (${{ matrix.os }} / Python ${{ matrix.python-version }})
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -121,9 +121,9 @@ jobs:
     name: Test notebooks (${{ matrix.os }} / Python ${{ matrix.python-version }})
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -144,13 +144,13 @@ jobs:
 
     steps:
       - name: Check out PyBOP repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 
       - name: Set up Python 3.12
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.12
 
@@ -175,10 +175,10 @@ jobs:
 
     steps:
       - name: Check out PyBOP repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python 3.12
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.12
           cache: 'pip'
@@ -191,7 +191,7 @@ jobs:
         run: nox -s coverage
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           fail_ci_if_error: true
           verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Topic :: Scientific/Engineering",
 ]
+# When updating the Python version ranges, please also bump the Python
+# versions in the tests in nightly_dependency_tests.yml as appropriate
 requires-python = ">=3.10, <3.14"
 dependencies = [
     "pybamm>=25.12.0",


### PR DESCRIPTION
# Description

This PR closes #297; it adds https://github.com/scientific-python/issue-from-pytest-log-action in order to allow opening issues from failures reported in our scheduled nightly tests. I've also bumped a number of our GitHub Actions versions, which were getting outdated.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) to document the change (include PR #).

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `$ pre-commit run` or `$ nox -s pre-commit` (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctest`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
