### PR TITLE
Fix nightly workflow again

### DIFF
--- a/.github/workflows/nightly_dependency_tests.yaml
+++ b/.github/workflows/nightly_dependency_tests.yaml
@@ -53,7 +53,7 @@ jobs:
         if: matrix.dep-type == 'latest'
         run: |
           uv pip install -e .[all,dev]
-          uv pip uninstall -y pybamm
+          uv pip uninstall pybamm
           uv pip install "pybamm[all] @ git+https://github.com/pybamm-team/PyBaMM@main"
           uv pip install pytest-reportlog
 


### PR DESCRIPTION
# Description

From #879 and #883: TIL that `uv pip` does not accept `-y` for "yes", it installs/uninstalls without prompting the user for input. This was missed when I changed `pip` to `uv pip` in the "latest" nightly tests. 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) to document the change (include PR #).

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `$ pre-commit run` or `$ nox -s pre-commit` (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctest`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
