### PR TITLE
fix failing nightly dependencies

### DIFF
--- a/.github/workflows/nightly_dependency_tests.yaml
+++ b/.github/workflows/nightly_dependency_tests.yaml
@@ -51,7 +51,9 @@ jobs:
 
       - name: Install dependencies (latest)
         if: matrix.dep-type == 'latest'
+        # uv pip install pip needed to allow %pip install within notebooks
         run: |
+          uv pip install pip
           uv pip install -e .[all]
           uv pip install --group dev
           uv pip uninstall pybamm
@@ -61,6 +63,7 @@ jobs:
       - name: Install dependencies (lowest)
         if: matrix.dep-type == 'lowest'
         run: |
+          uv pip install pip
           uv pip install --group dev
           uv pip install --resolution lowest-direct -e .[all]
           uv pip install pytest-reportlog


### PR DESCRIPTION
# Description

This fixes the issues causing the nightly dependencies to fail.

Fixes #886 #882 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) to document the change (include PR #).

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `$ pre-commit run` or `$ nox -s pre-commit` (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctest`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
