### PR TITLE
Check output variables exist in model variables

### DIFF
--- a/pybop/pybamm/simulator.py
+++ b/pybop/pybamm/simulator.py
@@ -446,6 +446,11 @@ class Simulator(BaseSimulator):
         return self._output_variables
 
     def set_output_variables(self, value: list[str] | None):
+        if value is not None:
+            for var in value:
+                if var not in self._model.variable_names():
+                    raise ValueError(f"{var} is not a variable in the model.")
+
         self._output_variables = value
         if self.experiment is None:
             self._set_up_solution_method(output_variables=value)

--- a/tests/unit/test_simulator.py
+++ b/tests/unit/test_simulator.py
@@ -1,3 +1,4 @@
+import pybamm
 import pytest
 
 import pybop
@@ -14,14 +15,10 @@ class TestSimulator:
     def test_parameter_errors_constructor(self):
         params = {
             "Negative particle radius [m]": pybop.Gaussian(
-                2e-05,
-                0.1e-5,
-                truncated_at=[1e-6, 5e-5],
+                2e-05, 0.1e-5, truncated_at=[1e-6, 5e-5]
             ),
             "Positive particle radius [m]": pybop.Gaussian(
-                0.5e-05,
-                0.1e-5,
-                truncated_at=[1e-6, 5e-5],
+                0.5e-05, 0.1e-5, truncated_at=[1e-6, 5e-5]
             ),
         }
 
@@ -32,20 +29,8 @@ class TestSimulator:
             BaseSimulator(params)
 
         params = [
-            pybop.Parameter(
-                pybop.Gaussian(
-                    2e-05,
-                    0.1e-5,
-                    truncated_at=[1e-6, 5e-5],
-                )
-            ),
-            pybop.Parameter(
-                pybop.Gaussian(
-                    2e-05,
-                    0.1e-5,
-                    truncated_at=[1e-6, 5e-5],
-                )
-            ),
+            pybop.Parameter(pybop.Gaussian(2e-05, 0.1e-5, truncated_at=[1e-6, 5e-5])),
+            pybop.Parameter(pybop.Gaussian(2e-05, 0.1e-5, truncated_at=[1e-6, 5e-5])),
         ]
 
         with pytest.raises(
@@ -53,3 +38,27 @@ class TestSimulator:
             match="The input parameters must be a a dictionary of Parameter objects or a pybop.Parameters object.",
         ):
             BaseSimulator(params)
+
+
+class TestPybammSimulator:
+    """
+    A class to test the pybamm.Simulator class.
+    """
+
+    pytestmark = pytest.mark.unit
+
+    def test_set_output_variables(self):
+        model = pybamm.lithium_ion.SPM()
+        parameter_values = model.default_parameter_values
+        experiment = pybamm.Experiment(
+            ["Discharge at 1C for 5 minutes (10 second period)"]
+        )
+
+        simulator = pybop.pybamm.Simulator(
+            model, parameter_values=parameter_values, protocol=experiment
+        )
+
+        with pytest.raises(
+            ValueError, match="Not a variable is not a variable in the model."
+        ):
+            simulator.set_output_variables(["Not a variable"])


### PR DESCRIPTION
# Description

Add a check that the output variables exist in the list of PyBaMM model variables before setting this property of the simulator.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) to document the change (include PR #).

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `$ pre-commit run` or `$ nox -s pre-commit` (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctest`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
