### PR TITLE
remove restriction on numpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Optimisations
 
 ## Bug Fixes
+- [#905](https://github.com/pybop-team/PyBOP/pull/905) - Remove restriction on numpy.
 
 ## Breaking Changes
 

--- a/pybop/plot/contour.py
+++ b/pybop/plot/contour.py
@@ -119,7 +119,7 @@ def contour(
                 ).get_values()
                 costs[j, i], sensitivities = out[0][0], out[1]
                 for k, key in enumerate(problem.parameters.names):
-                    grads[k][j, i] = sensitivities[key]
+                    grads[k][j, i] = sensitivities[key].item()
             else:
                 costs[j, i] = problem.evaluate(
                     np.asarray([xi, yj] + additional_values),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 requires-python = ">=3.10, <3.14"
 dependencies = [
     "pybamm>=25.12.0",
-    "numpy>=1.26, <2.4.0",
+    "numpy>=1.26",
     "scipy>=1.12",
     "pints>=0.5.1",
     "SALib>=1.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pybamm>=25.12.0",
     "numpy>=1.26",
     "scipy>=1.12",
-    "pints>=0.5.1",
+    "pints>=0.6.0",
     "SALib>=1.5",
 ]
 


### PR DESCRIPTION
# Description

Restriction on numpy version no longer necessary after most recent pints release
https://github.com/pints-team/pints/releases/tag/v0.6.0

Fixes #876 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) to document the change (include PR #).

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `$ pre-commit run` or `$ nox -s pre-commit` (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctest`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
