### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/test_on_pull_request.yaml
+++ b/.github/workflows/test_on_pull_request.yaml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.14"]
 
     name: Integration tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
 
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-15-intel, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude: # We run the coverage tests on macOS (arm64) with Python 3.12
           - os: macos-latest
             python-version: "3.12"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- [#940](https://github.com/pybop-team/PyBOP/pull/940) - Adds support for Python 3.14 (EP-BOLFI optimiser and PyProBE still restricted to Python 3.12 or below).
+
 ## Optimisations
 
 ## Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,13 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Intended Audience :: Science/Research",
   "Topic :: Scientific/Engineering",
 ]
 # When updating the Python version ranges, please also bump the Python
 # versions in the tests in nightly_dependency_tests.yml as appropriate
-requires-python = ">=3.10, <3.14"
+requires-python = ">=3.10, <3.15"
 dependencies = [
     "pybamm>=26.3.0",
     "numpy>=1.26",

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -100,7 +100,7 @@ class TestDataset:
         sys.version_info < (3, 11), reason="requires python3.11 or higher"
     )
     @pytest.mark.skipif(
-        sys.version_info >= (3, 13), reason="requires python3.13 or lower"
+        sys.version_info > (3, 12), reason="requires python3.12 or lower"
     )
     def test_pyprobe_import(self):
         """

--- a/tests/unit/test_optimisation.py
+++ b/tests/unit/test_optimisation.py
@@ -515,7 +515,7 @@ class TestOptimisation:
         assert result.scipy_result is not None
 
     @pytest.mark.skipif(
-        sys.version_info >= (3, 13), reason="requires python3.13 or lower"
+        sys.version_info > (3, 12), reason="requires python3.12 or lower"
     )
     def test_ep_bolfi(self, multivariate_problem, gitt_like_problem):
         options = pybop.EPBOLFIOptions()


### PR DESCRIPTION
# Description

Extend support to Python 3.14.

Fixes #939 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) to document the change (include PR #).

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `$ pre-commit run` or `$ nox -s pre-commit` (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctest`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
