### PR TITLE
Update our classifiers, better licensing, and migrate to hatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=64"]
-build-backend = "setuptools.build_meta"
+requires = ["hatch"]
+build-backend = "hatchling.build"
 
 [project]
 name = "pybop"
@@ -76,8 +76,40 @@ dev = [
     "ruff",
 ]
 
-[tool.setuptools.packages.find]
-include = ["pybop", "pybop.*"]
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "papers/",
+  "tests/",
+  "benchmarks/",
+  "docs/",
+  "assets/",
+  "scripts/",
+  "multiprocessing_bench.py",
+  "noxfile.py",
+  "asv.conf.json",
+  "conftest.py",
+  "CONTRIBUTING.md",
+]
+
+# the wheel additionally excludes files that are not needed for installation, such 
+#as the changelog and citation files, and the examples. those are present in the sdist.
+[tool.hatch.build.targets.wheel]
+exclude = [
+  "papers/",
+  "tests/",
+  "benchmarks/",
+  "docs/",
+  "assets/",
+  "scripts/",
+  "examples/",
+  "multiprocessing_bench.py",
+  "noxfile.py",
+  "asv.conf.json",
+  "conftest.py",
+  "CONTRIBUTING.md",
+  "CHANGELOG.md",
+  "CITATION.cff",
+]
 
 [project.urls]
 Homepage = "https://github.com/pybop-team/PyBOP"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,10 @@ maintainers = [
 ]
 description = "Python Battery Optimisation and Parameterisation"
 readme = {file = "README.md", content-type = "text/markdown"}
-license = { file = "LICENSE" }
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 classifiers = [
   "Development Status :: 3 - Alpha",
-  "License :: OSI Approved :: BSD License",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = {file = "README.md", content-type = "text/markdown"}
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ exclude = [
   "CONTRIBUTING.md",
 ]
 
-# the wheel additionally excludes files that are not needed for installation, such 
+# the wheel additionally excludes files that are not needed for installation, such
 #as the changelog and citation files, and the examples. those are present in the sdist.
 [tool.hatch.build.targets.wheel]
 exclude = [


### PR DESCRIPTION
# Description

- Remove discouraged license classifier and switch to PEP 639 licensing standards (SPDX `license` expression and `license-file`)
- Switch the build backend to hatchling instead of setuptools (faster, less buggy, better-licensed)
- Move our project from alpha to a beta stage

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) to document the change (include PR #).

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `$ pre-commit run` or `$ nox -s pre-commit` (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctest`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
