### PR TITLE
Ensure costs return evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ## Breaking Changes
 
+- [#942](https://github.com/pybop-team/PyBOP/pull/942) - Adds `evaluate_batch` to the costs and ensures that an `Evaluation` is returned.
+
 # [v26.3](https://github.com/pybop-team/PyBOP/tree/v26.3) - 2026-03-05
 
 ## Features

--- a/examples/notebooks/comparison_examples/comparing_cost_functions.ipynb
+++ b/examples/notebooks/comparison_examples/comparing_cost_functions.ipynb
@@ -152,14 +152,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.3026101740368053e-09 1.4838261744640228e-05\n"
+      "[3.30221688e-09] [1.48373782e-05]\n"
      ]
     }
    ],
    "source": [
-    "SSE_cost = SSE.evaluate(solution, inputs)\n",
-    "RMSE_cost = RMSE.evaluate(solution, inputs)\n",
-    "print(SSE_cost, RMSE_cost)"
+    "SSE_value = SSE.evaluate(solution, inputs).get_values()\n",
+    "RMSE_value = RMSE.evaluate(solution, inputs).get_values()\n",
+    "print(SSE_value, RMSE_value)"
    ]
   },
   {
@@ -180,8 +180,8 @@
      "text": [
       "Samples: [[8.13658824e-05 5.78129588e-06]\n",
       " [8.49368515e-05 5.25871051e-06]]\n",
-      "SSE costs: [1.1526402047573603e-05, 0.0008508296049987403]\n",
-      "RMSE costs: [0.0008765995683158723, 0.007531399183855726]\n"
+      "SSE costs: [1.15262672e-05 8.50813826e-04]\n",
+      "RMSE costs: [0.00087659 0.00753133]\n"
      ]
     }
    ],
@@ -190,14 +190,8 @@
     "print(\"Samples:\", samples)\n",
     "inputs = [simulator.parameters.to_dict(s) for s in samples]\n",
     "solution = simulator.solve(inputs)\n",
-    "print(\n",
-    "    \"SSE costs:\",\n",
-    "    [SSE.evaluate(sol, x) for sol, x in zip(solution, inputs, strict=False)],\n",
-    ")\n",
-    "print(\n",
-    "    \"RMSE costs:\",\n",
-    "    [RMSE.evaluate(sol, x) for sol, x in zip(solution, inputs, strict=False)],\n",
-    ")"
+    "print(\"SSE costs:\", SSE.evaluate(solution, inputs).get_values())\n",
+    "print(\"RMSE costs:\", RMSE.evaluate(solution, inputs).get_values())"
    ]
   },
   {
@@ -267,8 +261,8 @@
     "x_range = np.linspace(4.72e-06, 5.72e-06, 25)\n",
     "inputs = [simulator.parameters.to_dict([7.56e-05, i]) for i in x_range]\n",
     "solution = simulator.solve(inputs)\n",
-    "y_SSE = [SSE.evaluate(sol, x) for sol, x in zip(solution, inputs, strict=False)]\n",
-    "y_RMSE = [RMSE.evaluate(sol, x) for sol, x in zip(solution, inputs, strict=False)]\n",
+    "y_SSE = SSE.evaluate(solution, inputs).get_values()\n",
+    "y_RMSE = RMSE.evaluate(solution, inputs).get_values()\n",
     "\n",
     "fig = go.Figure()\n",
     "fig.add_trace(go.Scatter(x=x_range, y=y_SSE, mode=\"lines\", name=\"SSE\"))\n",
@@ -341,9 +335,7 @@
    ],
    "source": [
     "minkowski = pybop.Minkowski(dataset, p=2)\n",
-    "y_minkowski = [\n",
-    "    minkowski.evaluate(sol, x) for sol, x in zip(solution, inputs, strict=False)\n",
-    "]\n",
+    "y_minkowski = minkowski.evaluate(solution, inputs).get_values()\n",
     "\n",
     "fig = go.Figure()\n",
     "fig.add_trace(\n",
@@ -423,9 +415,7 @@
     "y_minkowski_p = []\n",
     "for p in p_orders:\n",
     "    minkowski_p = pybop.Minkowski(dataset, p=p)\n",
-    "    y_minkowski_p.append(\n",
-    "        [minkowski_p.evaluate(sol, x) for sol, x in zip(solution, inputs, strict=False)]\n",
-    "    )\n",
+    "    y_minkowski_p.append(minkowski_p.evaluate(solution, inputs).get_values())\n",
     "\n",
     "fig = go.Figure()\n",
     "for i, p in enumerate(p_orders):\n",
@@ -498,9 +488,7 @@
    ],
    "source": [
     "sumofpower = pybop.SumOfPower(dataset, p=2)\n",
-    "y_sumofpower = [\n",
-    "    sumofpower.evaluate(sol, x) for sol, x in zip(solution, inputs, strict=False)\n",
-    "]\n",
+    "y_sumofpower = sumofpower.evaluate(solution, inputs).get_values()\n",
     "\n",
     "fig = go.Figure()\n",
     "fig.add_trace(\n",
@@ -585,17 +573,10 @@
     "y_sumofpower_p = []\n",
     "for p in p_orders:\n",
     "    minkowski_p = pybop.Minkowski(dataset, p=p)\n",
-    "    y_minkowski_p.append(\n",
-    "        [minkowski_p.evaluate(sol, x) for sol, x in zip(solution, inputs, strict=False)]\n",
-    "    )\n",
+    "    y_minkowski_p.append(minkowski_p.evaluate(solution, inputs).get_values())\n",
     "\n",
     "    sumofpower_p = pybop.SumOfPower(dataset, p=p)\n",
-    "    y_sumofpower_p.append(\n",
-    "        [\n",
-    "            sumofpower_p.evaluate(sol, x)\n",
-    "            for sol, x in zip(solution, inputs, strict=False)\n",
-    "        ]\n",
-    "    )\n",
+    "    y_sumofpower_p.append(sumofpower_p.evaluate(solution, inputs).get_values())\n",
     "\n",
     "fig = go.Figure()\n",
     "for i, p in enumerate(p_orders):\n",

--- a/examples/notebooks/getting_started/cost_compute_methods.ipynb
+++ b/examples/notebooks/getting_started/cost_compute_methods.ipynb
@@ -126,7 +126,7 @@
     {
      "data": {
       "text/plain": [
-       "0.08964370830751214"
+       "array([0.08964175])"
       ]
      },
      "execution_count": null,
@@ -156,7 +156,7 @@
     {
      "data": {
       "text/plain": [
-       "0.08964370830751214"
+       "array([0.08964175])"
       ]
      },
      "execution_count": null,
@@ -167,7 +167,7 @@
    "source": [
     "problem = pybop.Problem(simulator, cost)\n",
     "evaluation = problem.evaluate(inputs)\n",
-    "evaluation.get_values()[0]"
+    "evaluation.get_values()"
    ]
   },
   {
@@ -206,7 +206,7 @@
     {
      "data": {
       "text/plain": [
-       "0.08963951979661305"
+       "array([0.08963757])"
       ]
      },
      "execution_count": null,
@@ -253,9 +253,7 @@
     {
      "data": {
       "text/plain": [
-       "(0.09132023936765772,\n",
-       " {'Negative electrode active material volume fraction': -0.5825626322544761,\n",
-       "  'Positive electrode active material volume fraction': -0.4879808197216336})"
+       "(array([0.09131827]), {'Negative electrode active material volume fraction': array([-0.58254546]), 'Positive electrode active material volume fraction': array([-0.48797417])})"
       ]
      },
      "execution_count": null,
@@ -284,9 +282,9 @@
     {
      "data": {
       "text/plain": [
-       "(array([0.08964371]),\n",
-       " {'Negative electrode active material volume fraction': array([-0.5804802]),\n",
-       "  'Positive electrode active material volume fraction': array([-0.48654994])})"
+       "(array([0.08964175]),\n",
+       " {'Negative electrode active material volume fraction': array([-0.58046306]),\n",
+       "  'Positive electrode active material volume fraction': array([-0.48654329])})"
       ]
      },
      "execution_count": null,

--- a/pybop/costs/base_cost.py
+++ b/pybop/costs/base_cost.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterable
+
 import numpy as np
 
 from pybop._utils import add_spaces
@@ -57,8 +59,8 @@ class BaseCost:
 
     def evaluate(
         self,
-        solution: Solution,
-        inputs: Inputs | None = None,
+        solution: Solution | list[Solution],
+        inputs: Inputs | list[Inputs] | None = None,
         calculate_sensitivities: bool = False,
     ) -> Evaluation:
         """
@@ -66,10 +68,44 @@ class BaseCost:
 
         Parameters
         ----------
-        solution : pybop.Solution | pybamm.Solution
-            The simulation result.
-        inputs : Inputs, optional
-            Input parameters (default: None).
+        solution : Solution | list[Solution]
+            The simulation result or a list of results.
+        inputs : Inputs | list[Inputs], optional
+            Input parameters or a list of inputs (default: None).
+        calculate_sensitivities : bool
+            Whether to also return the sensitivities (default: False).
+        """
+        solution_list = solution if isinstance(solution, list) else [solution]
+
+        inputs = inputs or self.parameters.to_dict("initial")
+        inputs_list = inputs if isinstance(inputs, list) else [inputs]
+        if len(inputs_list) != len(solution_list):
+            raise ValueError(
+                f"The number of solutions ({len(solution_list)}) must match "
+                f"the number of inputs ({len(inputs_list)})."
+            )
+
+        return self.evaluate_batch(
+            solution=solution_list,
+            inputs=inputs_list,
+            calculate_sensitivities=calculate_sensitivities,
+        )
+
+    def evaluate_batch(
+        self,
+        solution: list[Solution],
+        inputs: list[Inputs],
+        calculate_sensitivities: bool = False,
+    ) -> Evaluation:
+        """
+        Computes the cost function for the given predictions.
+
+        Parameters
+        ----------
+        solution : list[Solution]
+            A list of simulation results.
+        inputs : list[Inputs]
+            The corresponding list of input parameters.
         calculate_sensitivities : bool
             Whether to also return the sensitivities (default: False).
         """
@@ -112,14 +148,13 @@ class BaseCost:
             de = float(de)
         self._de = de
 
-    def failure(self, parameter_names: list[str], calculate_sensitivities: bool = True):
+    def failure(
+        self, parameter_names: Iterable[str], calculate_sensitivities: bool = True
+    ):
         sign = 1.0 if self.minimising else -1.0
-        return Evaluation(
-            values=sign * np.inf,
-            sensitivities={key: sign * self._de for key in parameter_names}
-            if calculate_sensitivities
-            else None,
-        )
+        if calculate_sensitivities:
+            return (sign * np.inf, {key: sign * self._de for key in parameter_names})
+        return sign * np.inf
 
     @property
     def name(self):
@@ -156,32 +191,48 @@ class LogPrior(BaseCost):
         self.parameters = parameters
         self.minimising = False
 
-    def evaluate(
+    def evaluate_batch(
         self,
-        solution: Solution,
-        inputs: Inputs | None = None,
+        solution: list[Solution],
+        inputs: list[Inputs],
         calculate_sensitivities: bool = False,
     ) -> Evaluation:
         """
         Computes the log-prior for the given inputs, and optionally the sensitivities.
+
+        Parameters
+        ----------
+        solution : list[Solution]
+            A list of simulation results.
+        inputs : list[Inputs]
+            The corresponding list of input parameters.
+        calculate_sensitivities : bool
+            Whether to also return the sensitivities (default: False).
         """
-        # Get the values of all input parameters
-        inputs = inputs or self.parameters.to_dict("initial")
-        input_values = np.asarray(list(inputs.values()))
+        l = np.empty(len(solution))
+        dl = (
+            {key: np.zeros(len(solution)) for key in inputs[0].keys()}
+            if calculate_sensitivities
+            else None
+        )
 
-        # Compute log prior (and gradient)
-        if calculate_sensitivities:
-            l, dl = self.parameters.distribution.logpdfS1(input_values)
-            dl = {key: dl[i] for i, key in enumerate(self.parameters.names)}
-        else:
-            l = self.parameters.distribution.logpdf(input_values)
+        for i, x in enumerate(inputs):
+            # Get the values of all input parameters
+            input_values = np.asarray(list(x.values()))
 
-        if not np.isfinite(l).any():
-            return self.failure(
-                inputs=inputs, calculate_sensitivities=calculate_sensitivities
-            )
+            # Compute log prior (and gradient)
+            if calculate_sensitivities:
+                l[i], dl_array = self.parameters.distribution.logpdfS1(input_values)
+                dl_i = {key: dl_array[i_key] for i_key, key in enumerate(x.keys())}
 
-        if calculate_sensitivities:
-            return Evaluation(values=l, sensitivities=dl)
+                # Use failure gradient for any infinite log prior
+                if not np.isfinite(l[i]):
+                    l[i], dl_i = self.failure(x.keys(), calculate_sensitivities)
 
-        return Evaluation(values=l)
+                for key in x.keys():
+                    dl[key][i] = dl_i[key]
+
+            else:
+                l[i] = self.parameters.distribution.logpdf(input_values)
+
+        return Evaluation(values=l, sensitivities=dl)

--- a/pybop/costs/base_cost.py
+++ b/pybop/costs/base_cost.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from pybop._utils import add_spaces
+from pybop.costs.evaluation import Evaluation
 from pybop.parameters.parameter import Inputs, Parameters
 from pybop.processing.dataset import Dataset
 from pybop.simulators.solution import Solution
@@ -59,7 +60,7 @@ class BaseCost:
         solution: Solution,
         inputs: Inputs | None = None,
         calculate_sensitivities: bool = False,
-    ) -> float | tuple[float, np.ndarray]:
+    ) -> Evaluation:
         """
         Computes the cost function for the given predictions.
 
@@ -71,12 +72,6 @@ class BaseCost:
             Input parameters (default: None).
         calculate_sensitivities : bool
             Whether to also return the sensitivities (default: False).
-
-        Returns
-        -------
-        np.float64 or tuple[np.float64, np.ndarray[np.float64]]
-            If the solution has sensitivities, returns a tuple containing the cost (float) and the
-            gradient with dimension (len(parameters)), otherwise returns only the cost.
         """
         raise NotImplementedError
 
@@ -118,14 +113,13 @@ class BaseCost:
         self._de = de
 
     def failure(self, parameter_names: list[str], calculate_sensitivities: bool = True):
-        if calculate_sensitivities:
-            return (
-                (np.inf, {key: self._de for key in parameter_names})
-                if self.minimising
-                else (-np.inf, {key: -self._de for key in parameter_names})
-            )
-        else:
-            return np.inf if self.minimising else -np.inf
+        sign = 1.0 if self.minimising else -1.0
+        return Evaluation(
+            values=sign * np.inf,
+            sensitivities={key: sign * self._de for key in parameter_names}
+            if calculate_sensitivities
+            else None,
+        )
 
     @property
     def name(self):
@@ -167,7 +161,7 @@ class LogPrior(BaseCost):
         solution: Solution,
         inputs: Inputs | None = None,
         calculate_sensitivities: bool = False,
-    ) -> float | tuple[float, np.ndarray]:
+    ) -> Evaluation:
         """
         Computes the log-prior for the given inputs, and optionally the sensitivities.
         """
@@ -188,6 +182,6 @@ class LogPrior(BaseCost):
             )
 
         if calculate_sensitivities:
-            return l, dl
+            return Evaluation(values=l, sensitivities=dl)
 
-        return l
+        return Evaluation(values=l)

--- a/pybop/costs/design_cost.py
+++ b/pybop/costs/design_cost.py
@@ -1,4 +1,5 @@
 from pybop.costs.base_cost import BaseCost
+from pybop.costs.evaluation import Evaluation
 from pybop.parameters.parameter import Inputs
 from pybop.simulators.base_simulator import Solution
 from pybop.simulators.failed_solution import FailedSolution
@@ -22,14 +23,14 @@ class DesignCost(BaseCost):
         self.minimising = False
         self.set_target(target)
 
-    def evaluate(
+    def __call__(
         self,
         solution: Solution | FailedSolution,
         inputs: Inputs | None = None,
         calculate_sensitivities: bool = False,
     ) -> float:
         """
-        Returns the value of the cost variable.
+        Compute the value of the cost variable.
 
         Parameters
         ----------
@@ -50,3 +51,23 @@ class DesignCost(BaseCost):
             return self.failure(self.parameters.names, calculate_sensitivities)
 
         return solution[self.target[0]].data[-1]
+
+    def evaluate(
+        self,
+        solution: Solution | FailedSolution,
+        inputs: Inputs | None = None,
+        calculate_sensitivities: bool = False,
+    ) -> Evaluation:
+        """
+        Returns the value of the cost variable.
+
+        Parameters
+        ----------
+        solution : pybop.Solution | pybamm.Solution
+            The simulation result.
+        inputs : Inputs, optional
+            Input parameters (default: None).
+        calculate_sensitivities : bool
+            Whether to also return the sensitivities (default: False).
+        """
+        return Evaluation(values=self.__call__(solution, inputs))

--- a/pybop/costs/design_cost.py
+++ b/pybop/costs/design_cost.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from pybop.costs.base_cost import BaseCost
 from pybop.costs.evaluation import Evaluation
 from pybop.parameters.parameter import Inputs
@@ -52,10 +54,10 @@ class DesignCost(BaseCost):
 
         return solution[self.target[0]].data[-1]
 
-    def evaluate(
+    def evaluate_batch(
         self,
-        solution: Solution | FailedSolution,
-        inputs: Inputs | None = None,
+        solution: list[Solution],
+        inputs: list[Inputs],
         calculate_sensitivities: bool = False,
     ) -> Evaluation:
         """
@@ -63,11 +65,16 @@ class DesignCost(BaseCost):
 
         Parameters
         ----------
-        solution : pybop.Solution | pybamm.Solution
-            The simulation result.
-        inputs : Inputs, optional
-            Input parameters (default: None).
+        solution : list[Solution]
+            A list of simulation results.
+        inputs : list[Inputs]
+            The corresponding list of input parameters.
         calculate_sensitivities : bool
             Whether to also return the sensitivities (default: False).
         """
-        return Evaluation(values=self.__call__(solution, inputs))
+        e = np.empty(len(solution))
+
+        for i, (sol, x) in enumerate(zip(solution, inputs, strict=False)):
+            e[i] = self.__call__(solution=sol, inputs=x)
+
+        return Evaluation(values=e)

--- a/pybop/costs/error_measures.py
+++ b/pybop/costs/error_measures.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pybamm
 
 from pybop.costs.base_cost import BaseCost
 from pybop.costs.evaluation import Evaluation
@@ -71,10 +70,10 @@ class ErrorMeasure(BaseCost):
         else:
             self.weighting = np.asarray(weighting)
 
-    def evaluate(
+    def evaluate_batch(
         self,
-        solution: Solution | pybamm.Solution | FailedSolution,
-        inputs: Inputs | None = None,
+        solution: list[Solution],
+        inputs: list[Inputs],
         calculate_sensitivities: bool = False,
     ) -> Evaluation:
         """
@@ -82,38 +81,48 @@ class ErrorMeasure(BaseCost):
 
         Parameters
         ----------
-        solution : pybop.Solution | pybamm.Solution
-            The simulation result.
-        inputs : Inputs, optional
-            Input parameters (default: None).
+        Parameters
+        ----------
+        solution : list[Solution]
+            A list of simulation results.
+        inputs : list[Inputs]
+            The corresponding list of input parameters.
         calculate_sensitivities : bool
             Whether to also return the sensitivities (default: False).
         """
-        # Return failure cost if the solution failed
-        if isinstance(solution, FailedSolution):
-            return self.failure(self.parameters.names, calculate_sensitivities)
-
-        if not isinstance(solution, (Solution, pybamm.Solution)):
-            raise ValueError(
-                f"solution must be a pybop.Solution object, got type {type(solution)} with value {solution}."
-            )
-
-        # Early return if the prediction is not verified
-        if not self.verify_prediction(solution):
-            return self.failure(self.parameters.names, calculate_sensitivities)
-
-        # Compute the residual for all output variables
-        r = np.asarray(
-            [solution[var].data - self._target_data[var] for var in self.target]
+        e = np.empty(len(solution))
+        de = (
+            {key: np.zeros(len(solution)) for key in inputs[0].keys()}
+            if calculate_sensitivities
+            else None
         )
 
-        if calculate_sensitivities:
-            # Extract the sensitivities for all output variables and parameters
-            dy = self.stack_sensitivities(solution)
-            e, de = self.__call__(r=r, dy=dy, inputs=inputs)
-            return Evaluation(values=e, sensitivities=de)
+        for i, (sol, x) in enumerate(zip(solution, inputs, strict=False)):
+            # Return failure cost if the solution failed
+            if isinstance(sol, FailedSolution) or not self.verify_prediction(sol):
+                if calculate_sensitivities:
+                    e[i], de_i = self.failure(x.keys(), calculate_sensitivities)
+                else:
+                    e[i] = self.failure(x.keys(), calculate_sensitivities)
 
-        return Evaluation(values=self.__call__(r=r, inputs=inputs))
+            else:
+                # Compute the residual for all output variables
+                r = np.asarray(
+                    [sol[var].data - self._target_data[var] for var in self.target]
+                )
+
+                if calculate_sensitivities:
+                    # Extract the sensitivities for all output variables and parameters
+                    dy = self.stack_sensitivities(sol)
+                    e[i], de_i = self.__call__(r=r, dy=dy, inputs=x)
+                else:
+                    e[i] = self.__call__(r=r, inputs=x)
+
+            if calculate_sensitivities:
+                for key in x.keys():
+                    de[key][i] = de_i[key]
+
+        return Evaluation(values=e, sensitivities=de)
 
     def verify_prediction(self, solution: Solution):
         """

--- a/pybop/costs/error_measures.py
+++ b/pybop/costs/error_measures.py
@@ -2,6 +2,7 @@ import numpy as np
 import pybamm
 
 from pybop.costs.base_cost import BaseCost
+from pybop.costs.evaluation import Evaluation
 from pybop.parameters.parameter import Inputs
 from pybop.processing.dataset import Dataset
 from pybop.simulators.failed_solution import FailedSolution
@@ -75,7 +76,7 @@ class ErrorMeasure(BaseCost):
         solution: Solution | pybamm.Solution | FailedSolution,
         inputs: Inputs | None = None,
         calculate_sensitivities: bool = False,
-    ) -> float | tuple[float, np.ndarray]:
+    ) -> Evaluation:
         """
         Computes the cost function for the given predictions.
 
@@ -87,12 +88,6 @@ class ErrorMeasure(BaseCost):
             Input parameters (default: None).
         calculate_sensitivities : bool
             Whether to also return the sensitivities (default: False).
-
-        Returns
-        -------
-        np.float64 or tuple[np.float64, np.ndarray[np.float64]]
-            If the solution has sensitivities, returns a tuple containing the cost (float) and the
-            gradient with dimension (len(parameters)), otherwise returns only the cost.
         """
         # Return failure cost if the solution failed
         if isinstance(solution, FailedSolution):
@@ -112,10 +107,13 @@ class ErrorMeasure(BaseCost):
             [solution[var].data - self._target_data[var] for var in self.target]
         )
 
-        # Extract the sensitivities for all output variables and parameters
-        dy = self.stack_sensitivities(solution) if calculate_sensitivities else None
+        if calculate_sensitivities:
+            # Extract the sensitivities for all output variables and parameters
+            dy = self.stack_sensitivities(solution)
+            e, de = self.__call__(r=r, dy=dy, inputs=inputs)
+            return Evaluation(values=e, sensitivities=de)
 
-        return self.__call__(r=r, dy=dy, inputs=inputs)
+        return Evaluation(values=self.__call__(r=r, inputs=inputs))
 
     def verify_prediction(self, solution: Solution):
         """

--- a/pybop/costs/evaluation.py
+++ b/pybop/costs/evaluation.py
@@ -13,6 +13,9 @@ class Evaluation:
     ):
         self.values = np.atleast_1d(values)
         self.sensitivities = sensitivities
+        if sensitivities is not None:
+            for key, value in sensitivities.items():
+                self.sensitivities[key] = np.atleast_1d(value)
 
     def preallocate(self, inputs, calculate_sensitivities: bool = None):
         self.all_inputs = inputs
@@ -24,10 +27,9 @@ class Evaluation:
         else:
             self.sensitivities = None
 
-    def insert_result(
-        self, i: int, value: float, sensitivities: dict[str, np.ndarray] | None = None
-    ):
-        self.values[i] = value
+    def insert_result(self, i: int, evaluation):
+        self.values[i] = evaluation.values.item()
+        sensitivities = evaluation.sensitivities
         if sensitivities is not None:
             for key, value in sensitivities.items():
                 self.sensitivities[key][i] = value
@@ -39,3 +41,6 @@ class Evaluation:
 
     def __len__(self):
         return len(self.values)
+
+    def __repr__(self) -> str:
+        return self.get_values().__repr__()

--- a/pybop/costs/evaluation.py
+++ b/pybop/costs/evaluation.py
@@ -32,7 +32,7 @@ class Evaluation:
         sensitivities = evaluation.sensitivities
         if sensitivities is not None:
             for key, value in sensitivities.items():
-                self.sensitivities[key][i] = value
+                self.sensitivities[key][i] = value.item()
 
     def get_values(self) -> np.ndarray | tuple[np.ndarray, dict[str, np.ndarray]]:
         if self.sensitivities is None:

--- a/pybop/costs/evaluation.py
+++ b/pybop/costs/evaluation.py
@@ -27,9 +27,10 @@ class Evaluation:
         else:
             self.sensitivities = None
 
-    def insert_result(self, i: int, evaluation):
-        self.values[i] = evaluation.values.item()
-        sensitivities = evaluation.sensitivities
+    def insert_result(
+        self, i: int, value: float, sensitivities: dict[str, np.ndarray] | None = None
+    ):
+        self.values[i] = value
         if sensitivities is not None:
             for key, value in sensitivities.items():
                 self.sensitivities[key][i] = value.item()

--- a/pybop/costs/weighted_cost.py
+++ b/pybop/costs/weighted_cost.py
@@ -57,10 +57,10 @@ class WeightedCost(BaseCost):
             self.weights = -self.weights
             self.minimising = False
 
-    def evaluate(
+    def evaluate_batch(
         self,
-        solution: Solution,
-        inputs: Inputs | None = None,
+        solution: list[Solution],
+        inputs: list[Inputs],
         calculate_sensitivities: bool = False,
     ) -> Evaluation:
         """
@@ -68,32 +68,45 @@ class WeightedCost(BaseCost):
 
         Parameters
         ----------
-        solution : pybop.Solution | pybamm.Solution
-            The simulation result.
-        inputs : Inputs, optional
-            Input parameters (default: None).
+        solution : list[Solution]
+            A list of simulation results.
+        inputs : list[Inputs]
+            The corresponding list of input parameters.
         calculate_sensitivities : bool
             Whether to also return the sensitivities (default: False).
         """
-        e = np.empty_like(self.costs)
-        de = {key: np.zeros(len(self.costs)) for key in inputs.keys()}
+        # Preallocate the evaluation results
+        weighted_evaluation = Evaluation()
+        weighted_evaluation.preallocate(
+            inputs=inputs, calculate_sensitivities=calculate_sensitivities
+        )
 
-        for i, cost in enumerate(self.costs):
-            evaluation = cost.evaluate(
-                solution, inputs=inputs, calculate_sensitivities=calculate_sensitivities
+        for j, (sol, x) in enumerate(zip(solution, inputs, strict=False)):
+            e = np.empty(len(self.costs))
+            de = (
+                {key: np.zeros(len(self.costs)) for key in x.keys()}
+                if calculate_sensitivities
+                else None
             )
-            e[i] = evaluation.values.item()
+
+            for i, cost in enumerate(self.costs):
+                evaluation = cost.evaluate(
+                    sol, inputs=x, calculate_sensitivities=calculate_sensitivities
+                )
+                e[i] = evaluation.values.item()
+                if calculate_sensitivities:
+                    for key, value in evaluation.sensitivities.items():
+                        de[key][i] = value.item()
+
+            # Sum with weighting
+            e = np.dot(e, self.weights)
             if calculate_sensitivities:
-                for key, value in evaluation.sensitivities.items():
-                    de[key][i] = value.item()
+                for key in de.keys():
+                    de[key] = np.dot(de[key], self.weights)
 
-        e = np.dot(e, self.weights)
-        if calculate_sensitivities:
-            for key in de.keys():
-                de[key] = np.dot(de[key], self.weights)
-            return Evaluation(values=e, sensitivities=de)
+            weighted_evaluation.insert_result(i=j, value=e, sensitivities=de)
 
-        return Evaluation(values=e)
+        return weighted_evaluation
 
     def set_target(self, target: list[list[str]] | list[str] | str | None = None):
         """Set the target variable for all costs. Expecting a list of list[str] the same length as self.costs."""

--- a/pybop/costs/weighted_cost.py
+++ b/pybop/costs/weighted_cost.py
@@ -85,7 +85,7 @@ class WeightedCost(BaseCost):
             e[i] = evaluation.values.item()
             if calculate_sensitivities:
                 for key, value in evaluation.sensitivities.items():
-                    de[key][i] = value
+                    de[key][i] = value.item()
 
         e = np.dot(e, self.weights)
         if calculate_sensitivities:

--- a/pybop/costs/weighted_cost.py
+++ b/pybop/costs/weighted_cost.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from pybop.costs.base_cost import BaseCost
 from pybop.costs.design_cost import DesignCost
+from pybop.costs.evaluation import Evaluation
 from pybop.parameters.parameter import Inputs
 from pybop.simulators.solution import Solution
 
@@ -61,7 +62,7 @@ class WeightedCost(BaseCost):
         solution: Solution,
         inputs: Inputs | None = None,
         calculate_sensitivities: bool = False,
-    ) -> float | tuple[float, np.ndarray]:
+    ) -> Evaluation:
         """
         Computes the cost function for the given predictions.
 
@@ -73,39 +74,26 @@ class WeightedCost(BaseCost):
             Input parameters (default: None).
         calculate_sensitivities : bool
             Whether to also return the sensitivities (default: False).
-
-        Returns
-        -------
-        np.float64 or tuple[np.float64, np.ndarray[np.float64]]
-            If the solution has sensitivities, returns a tuple containing the cost (float) and the
-            gradient with dimension (len(parameters)), otherwise returns only the cost.
         """
         e = np.empty_like(self.costs)
         de = {key: np.zeros(len(self.costs)) for key in inputs.keys()}
 
         for i, cost in enumerate(self.costs):
+            evaluation = cost.evaluate(
+                solution, inputs=inputs, calculate_sensitivities=calculate_sensitivities
+            )
+            e[i] = evaluation.values.item()
             if calculate_sensitivities:
-                e[i], sensitivities = cost.evaluate(
-                    solution,
-                    inputs=inputs,
-                    calculate_sensitivities=calculate_sensitivities,
-                )
-                for key, value in sensitivities.items():
+                for key, value in evaluation.sensitivities.items():
                     de[key][i] = value
-            else:
-                e[i] = cost.evaluate(
-                    solution,
-                    inputs=inputs,
-                    calculate_sensitivities=calculate_sensitivities,
-                )
 
         e = np.dot(e, self.weights)
         if calculate_sensitivities:
             for key in de.keys():
                 de[key] = np.dot(de[key], self.weights)
-            return e, de
+            return Evaluation(values=e, sensitivities=de)
 
-        return e
+        return Evaluation(values=e)
 
     def set_target(self, target: list[list[str]] | list[str] | str | None = None):
         """Set the target variable for all costs. Expecting a list of list[str] the same length as self.costs."""

--- a/pybop/plot/problem.py
+++ b/pybop/plot/problem.py
@@ -49,7 +49,7 @@ def problem(
         # Simulate the model for the both the initial and the given inputs
         target = problem.target
         problem.set_target(target + [domain])
-        initial_inputs = problem.simulator.parameters.to_dict("initial")
+        initial_inputs = problem.parameters.to_dict("initial")
         target_output = problem.simulate(initial_inputs)
         target_domain = target_output[domain].data
         model_output = problem.simulate(inputs)

--- a/pybop/problems/problem.py
+++ b/pybop/problems/problem.py
@@ -68,7 +68,7 @@ class Problem:
         evaluation = self.evaluate(inputs=inputs, calculate_sensitivities=False)
 
         return (
-            evaluation.values[0]
+            evaluation.values.item()
             if len(evaluation.values) == 1
             else evaluation.values.tolist()
         )
@@ -152,38 +152,20 @@ class Problem:
         # Evaluate the cost for the valid parameters
         valid_indices = [i for i, valid in enumerate(validity) if valid]
         # TODO: Parallelise the cost computations
-        if calculate_sensitivities:
-            for i, solution in enumerate(solutions):
-                e, de = self._cost.evaluate(
-                    solution,
-                    inputs=valid_inputs[i],
-                    calculate_sensitivities=calculate_sensitivities,
-                )
-                evaluation.insert_result(
-                    i=valid_indices[i], value=np.asarray(e).item(), sensitivities=de
-                )
-        else:
-            for i, solution in enumerate(solutions):
-                e = self._cost.evaluate(
-                    solution,
-                    inputs=valid_inputs[i],
-                    calculate_sensitivities=calculate_sensitivities,
-                )
-                evaluation.insert_result(i=valid_indices[i], value=np.asarray(e).item())
+        for i, solution in enumerate(solutions):
+            e = self._cost.evaluate(
+                solution,
+                inputs=valid_inputs[i],
+                calculate_sensitivities=calculate_sensitivities,
+            )
+            evaluation.insert_result(i=valid_indices[i], evaluation=e)
 
         if False in validity:
             # Insert failure outputs for the invalid parameters into the lists of results
             invalid_indices = [i for i, valid in enumerate(validity) if not valid]
-            if calculate_sensitivities:
-                y, dy = self._cost.failure(
-                    self.parameters.names, calculate_sensitivities
-                )
-                for i in invalid_indices:
-                    evaluation.insert_result(i=i, value=y, sensitivities=dy)
-            else:
-                y = self._cost.failure(self.parameters.names, calculate_sensitivities)
-                for i in invalid_indices:
-                    evaluation.insert_result(i=i, value=y)
+            e = self._cost.failure(self.parameters.names, calculate_sensitivities)
+            for i in invalid_indices:
+                evaluation.insert_result(i=i, evaluation=e)
 
         return evaluation
 
@@ -244,14 +226,14 @@ class Problem:
         Compute the absolute initial cost, resampling the initial parameters if needed.
         """
         x0 = self.parameters.get_initial_values()
-        cost0 = np.abs(self.evaluate(x0).values[0])
+        cost0 = np.abs(self.evaluate(x0).values.item())
         nsamples = 0
         while np.isinf(cost0) and nsamples < 10:
             x0 = self.parameters.sample_from_distribution()[0]
             if x0 is None:
                 break
 
-            cost0 = np.abs(self.evaluate(x0).values[0])
+            cost0 = np.abs(self.evaluate(x0).values.item())
             nsamples += 1
         if nsamples > 0:
             self.parameters.update(initial_values=x0)

--- a/pybop/problems/problem.py
+++ b/pybop/problems/problem.py
@@ -128,46 +128,13 @@ class Problem:
         if calculate_sensitivities:
             calculate_sensitivities = self._has_sensitivities
 
-        validity = []
-        valid_inputs = []
-        for x in inputs:
-            # Check the validity of the inputs so we only evaluate valid parameters
-            if self.parameters.verify_inputs(x):
-                validity.append(True)
-                valid_inputs.append(x)
-            else:
-                validity.append(False)
-
-        # Run simulations for the valid parameters
         solutions = self.simulate_batch(
-            valid_inputs, calculate_sensitivities=calculate_sensitivities
-        )
-
-        # Preallocate the evaluation results
-        evaluation = Evaluation()
-        evaluation.preallocate(
             inputs=inputs, calculate_sensitivities=calculate_sensitivities
         )
 
-        # Evaluate the cost for the valid parameters
-        valid_indices = [i for i, valid in enumerate(validity) if valid]
-        # TODO: Parallelise the cost computations
-        for i, solution in enumerate(solutions):
-            e = self._cost.evaluate(
-                solution,
-                inputs=valid_inputs[i],
-                calculate_sensitivities=calculate_sensitivities,
-            )
-            evaluation.insert_result(i=valid_indices[i], evaluation=e)
-
-        if False in validity:
-            # Insert failure outputs for the invalid parameters into the lists of results
-            invalid_indices = [i for i, valid in enumerate(validity) if not valid]
-            e = self._cost.failure(self.parameters.names, calculate_sensitivities)
-            for i in invalid_indices:
-                evaluation.insert_result(i=i, evaluation=e)
-
-        return evaluation
+        return self._cost.evaluate_batch(
+            solutions, inputs=inputs, calculate_sensitivities=calculate_sensitivities
+        )
 
     def simulate(
         self, inputs: Inputs | list[Inputs], calculate_sensitivities: bool = False
@@ -216,10 +183,28 @@ class Problem:
             A list of length(inputs) containing the simulated model output y(t) and (optionally)
             the sensitivities dy/dx(t) for output variable(s) y, domain t and parameter(s) x.
         """
-        model_inputs = [self.get_model_inputs(x) for x in inputs]
-        return self._simulator.solve_batch(
+        # Check the validity of the inputs so we only evaluate valid parameters
+        validity = []
+        valid_inputs = []
+        for x in inputs:
+            if self.parameters.verify_inputs(x):
+                validity.append(True)
+                valid_inputs.append(x)
+            else:
+                validity.append(False)
+
+        # Run simulations for the valid parameters
+        model_inputs = [self.get_model_inputs(x) for x in valid_inputs]
+        solutions = self._simulator.solve_batch(
             inputs=model_inputs, calculate_sensitivities=calculate_sensitivities
         )
+
+        # Insert failed solutions for any invalid inputs
+        invalid_indices = [i for i, valid in enumerate(validity) if not valid]
+        for i in invalid_indices:
+            solutions.insert(i, FailedSolution(self.target, inputs[i].keys()))
+
+        return solutions
 
     def get_finite_initial_cost(self):
         """

--- a/pybop/pybamm/eis_simulator.py
+++ b/pybop/pybamm/eis_simulator.py
@@ -289,9 +289,7 @@ class EISSimulator(BaseSimulator):
                 try:
                     simulations.append(self._solve(x))
                 except (ZeroDivisionError, RuntimeError, ValueError):
-                    simulations.append(
-                        FailedSolution(["Impedance"], [k for k in x.keys()])
-                    )
+                    simulations.append(FailedSolution(["Impedance"], x.keys()))
             return simulations
 
         simulations = []

--- a/pybop/simulators/failed_solution.py
+++ b/pybop/simulators/failed_solution.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -45,7 +46,7 @@ class FailedSolution:
         >>> print(voltage.data)  # np.ndarray([inf])
     """
 
-    def __init__(self, variable_names: list[str], parameter_names: list[str]):
+    def __init__(self, variable_names: Iterable[str], parameter_names: Iterable[str]):
         self._validate_inputs(variable_names, parameter_names)
         self._variable_names = variable_names
         self._parameter_names = parameter_names
@@ -125,14 +126,14 @@ class FailedSolution:
         """Get list of parameter names (read-only)."""
         return self._parameter_names.copy()
 
-    def keys(self) -> list[str]:
+    def keys(self) -> Iterator[str]:
         """Get all variable names."""
-        return list(self._variables.keys())
+        return self._variables.keys()
 
-    def values(self) -> list[FailedVariable]:
+    def values(self) -> Iterator[FailedVariable]:
         """Get all variables."""
-        return list(self._variables.values())
+        return self._variables.values()
 
-    def items(self) -> list[tuple[str, FailedVariable]]:
+    def items(self) -> Iterator[tuple[str, FailedVariable]]:
         """Get all variable name-value pairs."""
-        return list(self._variables.items())
+        return self._variables.items()


### PR DESCRIPTION
# Description

Align the cost and problem `evaluate` methods by ensuring that the costs also return a `pybop.Evaluation`.

To-do:
- [x]  enable a list of solutions and corresponding inputs to be evaluated in a single call
- [x] update the `comparing_cost_functions.ipynb` example notebook
- (future goal) enable costs to be evaluated in parallel

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) to document the change (include PR #).

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `$ pre-commit run` or `$ nox -s pre-commit` (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctest`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
