### PR TITLE
Fix Hessian integration tests

### DIFF
--- a/pybop/analysis/classification.py
+++ b/pybop/analysis/classification.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.linalg import eig
 
 from pybop import Result
 
@@ -124,7 +125,7 @@ def classify_using_hessian(
             cfd_hessian[1, 1] /= dx[1] ** 2
 
         # Compute the eigenvalues and sort into ascending order
-        eigenvalues, eigenvectors = np.linalg.eig(cfd_hessian)
+        eigenvalues, eigenvectors = eig(cfd_hessian)
         idx = eigenvalues.argsort()
         eigenvalues = eigenvalues[idx]
         eigenvectors = eigenvectors[:, idx]


### PR DESCRIPTION
# Description

Fix the eigenvector calculation in the Hessian-based classification tests by using `scipy.linalg.eig` instead of `np.linalg.eig`.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) to document the change (include PR #).

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `$ pre-commit run` or `$ nox -s pre-commit` (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctest`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
