### PR TITLE
Update the default solver options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Optimisations
 
+- [#967](https://github.com/pybop-team/PyBOP/pull/967) - Add `Dataset.get_discontinuities` and update the `pybop.pybamm.RecommendedSolver` options.
 - [#946](https://github.com/pybop-team/PyBOP/pull/946) - Use `vectorized` evaluation for SciPy differential evolution by default instead of multiprocessing `workers`.
 - [#925](https://github.com/pybop-team/PyBOP/pull/925) - Add `UnboundedDistribution` and the `get_transformed_distribution` functionality.
 

--- a/pybop/processing/dataset.py
+++ b/pybop/processing/dataset.py
@@ -146,6 +146,21 @@ class Dataset:
             data, domain=self.domain, control_functions=self.control_functions
         )
 
+    def get_discontinuities(self, tol: float = 1e-6) -> np.ndarray:
+        """Returns the start, end and any discontinuous points in the domain data."""
+        discontinuities = [np.atleast_2d([0, len(self.data[self.domain]) - 1])]
+
+        # Check all control variables for discontinuities
+        for key in self.control_functions:
+            control_data = self.data[key.replace(" function", "")]
+            var_tol = np.max(np.abs(control_data)) * tol
+            d = np.asarray(np.where(np.abs(np.diff(control_data)) > var_tol))
+            discontinuities.append(d)
+            discontinuities.append(d + 1)
+
+        ind = np.unique(np.hstack(discontinuities))
+        return self.data[self.domain][ind]
+
     def get_interpolant(self, control: str = "Current [A]") -> Interpolant:
         """Returns a linear interpolant for the control as a function of the domain."""
 

--- a/pybop/pybamm/simulator.py
+++ b/pybop/pybamm/simulator.py
@@ -183,16 +183,15 @@ class Simulator(BaseSimulator):
             self._t_interp = None
         elif isinstance(protocol, Dataset):
             self._experiment = None
-            time_data = protocol[protocol.domain]
-            self._t_eval = [time_data[0], time_data[-1]]
-            self._t_interp = time_data
+            self._t_eval = protocol.get_discontinuities()
+            self._t_interp = protocol[protocol.domain]
             for key in protocol.control_functions:
                 control = key.replace(" function", "")
                 self._parameter_values[key] = protocol.get_interpolant(control)
         else:
             self._experiment = None
             time_data = protocol
-            self._t_eval = [time_data[0], time_data[-1]]
+            self._t_eval = [time_data[0], time_data[-1]]  # ignores discontinuities
             self._t_interp = time_data
         # else:
         #     raise ValueError(f"Expected an experiment or a dataset. Received {type(protocol)}")

--- a/pybop/pybamm/simulator.py
+++ b/pybop/pybamm/simulator.py
@@ -373,7 +373,9 @@ class Simulator(BaseSimulator):
                             print(f"Ignoring this sample due to: {e}")
                         solutions.append(
                             FailedSolution(
-                                self.output_variables, self._input_parameter_names
+                                self.output_variables
+                                or self._model.default_quick_plot_variables,
+                                self._input_parameter_names,
                             )
                         )
                 return solutions
@@ -429,7 +431,8 @@ class Simulator(BaseSimulator):
         for solution in solutions:
             if hasattr(solution, "termination") and solution.termination == "failure":
                 failed_solution = FailedSolution(
-                    self.output_variables, self._input_parameter_names
+                    self.output_variables or self._model.default_quick_plot_variables,
+                    self._input_parameter_names,
                 )
                 processed_solutions.append(failed_solution)
             else:

--- a/pybop/pybamm/utils.py
+++ b/pybop/pybamm/utils.py
@@ -8,7 +8,7 @@ class RecommendedSolver(pybamm.IDAKLUSolver):
     """A shortcut for creating the PyBaMM solver recommended for optimisation."""
 
     def __init__(self, output_variables: list[str] | None = None):
-        solver_options = {}
+        solver_options = {"suppress_algebraic_error": True}
 
         if platform.system() != "Windows":
             solver_options["num_threads"] = max(1, mp.cpu_count())

--- a/tests/integration/test_model_experiment_changes.py
+++ b/tests/integration/test_model_experiment_changes.py
@@ -41,12 +41,8 @@ class TestModelAndExperimentChanges:
     def parameters_and_inputs(self, request):
         return request.param
 
-    @pytest.fixture
-    def solver(self):
-        return pybamm.IDAKLUSolver(atol=1e-6, rtol=1e-6)
-
     @pytest.mark.integration
-    def test_changing_experiment(self, parameters_and_inputs, solver):
+    def test_changing_experiment(self, parameters_and_inputs):
         parameters, inputs = parameters_and_inputs
         # Change the experiment and check that the results are different.
 
@@ -62,7 +58,6 @@ class TestModelAndExperimentChanges:
             parameter_values=parameter_values,
             initial_state=initial_state,
             protocol=t_eval,
-            solver=solver,
         )
         solution_1 = simulator_1.solve(inputs)
         cost_1 = self.final_cost(simulator_1, solution_1)
@@ -87,7 +82,7 @@ class TestModelAndExperimentChanges:
         np.testing.assert_allclose(cost_1, 0, atol=1e-5)
         np.testing.assert_allclose(cost_2, 0, atol=1e-5)
 
-    def test_changing_model(self, parameters_and_inputs, solver):
+    def test_changing_model(self, parameters_and_inputs):
         # Change the model and check that the results are different.
 
         parameter_values = pybamm.ParameterValues("Chen2020")
@@ -103,7 +98,6 @@ class TestModelAndExperimentChanges:
             parameter_values=parameter_values,
             protocol=experiment,
             initial_state=initial_state,
-            solver=solver,
         )
         solution_1 = simulator_1.solve(inputs)
         cost_1 = self.final_cost(simulator_1, solution_1)
@@ -114,7 +108,6 @@ class TestModelAndExperimentChanges:
             parameter_values=parameter_values,
             protocol=experiment,
             initial_state=initial_state,
-            solver=solver,
         )
         solution_2 = simulator_2.solve(inputs)
         cost_2 = self.final_cost(simulator_2, solution_2)
@@ -138,7 +131,7 @@ class TestModelAndExperimentChanges:
         result = optim.run()
         return result.best_cost
 
-    def test_multi_fitting_problem(self, solver):
+    def test_multi_fitting_problem(self):
         parameter_values = pybamm.ParameterValues("Chen2020")
         ground_truth = parameter_values[
             "Negative electrode active material volume fraction"
@@ -148,7 +141,7 @@ class TestModelAndExperimentChanges:
         experiment_1 = pybamm.Experiment(
             ["Discharge at 0.5C for 5 minutes (10 seconds period)"]
         )
-        dataset_1 = self.get_data(model_1, parameter_values, experiment_1, solver)
+        dataset_1 = self.get_data(model_1, parameter_values, experiment_1)
 
         parameter_values.update(
             {
@@ -158,10 +151,7 @@ class TestModelAndExperimentChanges:
             }
         )
         simulator_1 = pybop.pybamm.Simulator(
-            model_1,
-            parameter_values=parameter_values,
-            protocol=dataset_1,
-            solver=solver,
+            model_1, parameter_values=parameter_values, protocol=dataset_1
         )
 
         parameter_values.update(
@@ -171,7 +161,7 @@ class TestModelAndExperimentChanges:
         experiment_2 = pybamm.Experiment(
             ["Discharge at 1C for 3 minutes (10 seconds period)"]
         )
-        dataset_2 = self.get_data(model_2, parameter_values, experiment_2, solver)
+        dataset_2 = self.get_data(model_2, parameter_values, experiment_2)
 
         parameter_values.update(
             {
@@ -181,10 +171,7 @@ class TestModelAndExperimentChanges:
             }
         )
         simulator_2 = pybop.pybamm.Simulator(
-            model_2,
-            parameter_values=parameter_values,
-            protocol=dataset_2,
-            solver=solver,
+            model_2, parameter_values=parameter_values, protocol=dataset_2
         )
 
         # Define a problem for each dataset and combine them into one
@@ -204,11 +191,11 @@ class TestModelAndExperimentChanges:
             np.testing.assert_allclose(result.x, ground_truth, atol=2e-5)
             np.testing.assert_allclose(result.best_cost, 0, atol=3e-5)
 
-    def get_data(self, model, parameter_values, experiment, solver):
+    def get_data(self, model, parameter_values, experiment):
         solution = pybamm.Simulation(
             model,
             parameter_values=parameter_values,
             experiment=experiment,
-            solver=solver,
+            solver=pybop.pybamm.RecommendedSolver(),
         ).solve()
         return pybop.import_pybamm_solution(solution)

--- a/tests/unit/test_evaluation.py
+++ b/tests/unit/test_evaluation.py
@@ -18,10 +18,6 @@ class TestEvaluation:
         self.x_search = [1 / 0.25 * (self.x_model[0] - 0.375), np.log(self.x_model[1])]
 
     @pytest.fixture
-    def solver(self):
-        return pybamm.IDAKLUSolver(atol=5e-6, rtol=5e-6)
-
-    @pytest.fixture
     def model(self):
         return pybamm.lithium_ion.SPM()
 
@@ -45,21 +41,16 @@ class TestEvaluation:
         return pybamm.Experiment(["Discharge at 1C for 1 minutes (6 second period)"])
 
     @pytest.fixture
-    def dataset(self, model, experiment, solver):
-        solution = pybamm.Simulation(
-            model, experiment=experiment, solver=solver
-        ).solve()
+    def dataset(self, model, experiment):
+        solution = pybamm.Simulation(model, experiment=experiment).solve()
         return pybop.import_pybamm_solution(solution)
 
     @pytest.fixture
-    def simulator(self, model, parameters, dataset, solver, request):
+    def simulator(self, model, parameters, dataset, request):
         parameter_values = model.default_parameter_values
         parameter_values.update(parameters)
         return pybop.pybamm.Simulator(
-            model,
-            parameter_values=parameter_values,
-            protocol=dataset,
-            solver=solver,
+            model, parameter_values=parameter_values, protocol=dataset
         )
 
     @pytest.fixture(


### PR DESCRIPTION
# Description

Add discontinuities (if any) to the set of evaluation points `t_eval` and update the solver options for the `pybop.pybamm.RecommendedSolver`.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybop-team/PyBOP/blob/develop/CHANGELOG.md) to document the change (include PR #).

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `$ pre-commit run` or `$ nox -s pre-commit` (see [CONTRIBUTING.md](https://github.com/pybop-team/PyBOP/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctest`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
